### PR TITLE
Adapt homepage for smaller screens

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { VoiceControl } from '@/components/voice/VoiceControl';
 import { StartButtonOverlay } from '@/components/voice/StartButtonOverlay';
 import dynamic from 'next/dynamic';
-import { Mic, Send, StopCircle } from 'lucide-react';
+import { Mic, Send, StopCircle, X } from 'lucide-react';
 
 const Editor = dynamic(() => import('@/components/lessons/CodeEditor').then(mod => mod.CodeEditor), { ssr: false });
 const ReactRenderer = dynamic(() => import('@/components/lessons/ReactRenderer').then(mod => mod.ReactRenderer), { ssr: false });
@@ -116,10 +116,10 @@ function HomeComponent() {
     <div className="flex h-screen bg-background">
       <div className="flex-1 overflow-y-auto">
         <div className="container mx-auto py-6 px-4">
-          <div className="flex h-[calc(100vh-4rem)] gap-6 p-6 relative">
+          <div className="flex h-[calc(100vh-4rem)] gap-4 p-4 lg:gap-6 lg:p-6 relative pb-20 lg:pb-0">
             {!voiceActive && <StartButtonOverlay onStart={() => setVoiceActive(true)} />}
             {/* Left Panel - Chat Window */}
-            <div className="w-1/3 min-w-[350px] flex flex-col">
+            <div className="hidden lg:flex lg:w-1/3 lg:min-w-[350px] flex-col">
               <Card className="flex-1 flex flex-col h-full">
                 <CardHeader>
                   <CardTitle>AI Illustrative Explainer</CardTitle>
@@ -191,16 +191,31 @@ function HomeComponent() {
                   <CardHeader>
                     <div className="flex items-center justify-between">
                       <CardTitle>{getLibraryDisplayName()} Visualization</CardTitle>
-                      {debugMode && (
-                        <ToggleGroup
-                          type="single"
-                          value={show}
-                          onValueChange={(v: string | undefined) => v && setShow(v as 'render' | 'code')}
-                        >
-                          <ToggleGroupItem value="render">Rendering</ToggleGroupItem>
-                          <ToggleGroupItem value="code">Code</ToggleGroupItem>
-                        </ToggleGroup>
-                      )}
+                      <div className="flex items-center gap-2">
+                        {debugMode && (
+                          <ToggleGroup
+                            type="single"
+                            value={show}
+                            onValueChange={(v: string | undefined) => v && setShow(v as 'render' | 'code')}
+                          >
+                            <ToggleGroupItem value="render">Rendering</ToggleGroupItem>
+                            <ToggleGroupItem value="code">Code</ToggleGroupItem>
+                          </ToggleGroup>
+                        )}
+                        <div className="lg:hidden flex items-center gap-3">
+                          <span className={`w-3 h-3 rounded-full ${connectionStatus === 'connected' ? 'bg-emerald-500' : 'bg-gray-400'}`} />
+                          <Button
+                            type="button"
+                            size="icon"
+                            className="rounded-full bg-red-500 hover:bg-red-600 text-white w-9 h-9"
+                            onClick={() => setVoiceActive(false)}
+                            title="Disconnect"
+                          >
+                            <X className="w-5 h-5" />
+                          </Button>
+                          <Mic className="w-5 h-5 text-blue-500" />
+                        </div>
+                      </div>
                     </div>
                   </CardHeader>
                   <CardContent className="flex-1 flex flex-col p-0">
@@ -226,8 +241,26 @@ function HomeComponent() {
                   </CardContent>
                 </Card>
               ) : (
-                <Card className="flex-1 flex items-center justify-center">
-                  <CardContent>
+                <Card className="flex-1 flex flex-col">
+                  <CardHeader>
+                    <div className="flex items-center justify-between">
+                      <CardTitle>Visualization</CardTitle>
+                      <div className="lg:hidden flex items-center gap-3">
+                        <span className={`w-3 h-3 rounded-full ${connectionStatus === 'connected' ? 'bg-emerald-500' : 'bg-gray-400'}`} />
+                        <Button
+                          type="button"
+                          size="icon"
+                          className="rounded-full bg-red-500 hover:bg-red-600 text-white w-9 h-9"
+                          onClick={() => setVoiceActive(false)}
+                          title="Disconnect"
+                        >
+                          <X className="w-5 h-5" />
+                        </Button>
+                        <Mic className="w-5 h-5 text-blue-500" />
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="flex-1 flex items-center justify-center">
                     <div className="text-center text-muted-foreground">
                       <div className="text-lg mb-2">No visualization yet</div>
                       <div className="text-sm">Ask a question to generate a visualization, quiz, or interactive component</div>
@@ -236,6 +269,23 @@ function HomeComponent() {
                 </Card>
               )}
             </div>
+          </div>
+        </div>
+      </div>
+      <div className="fixed bottom-0 left-0 right-0 z-50 bg-transparent lg:hidden">
+        <div className="flex items-center justify-center py-3">
+          <div className="flex items-center gap-4">
+            <span className={`w-3 h-3 rounded-full ${connectionStatus === 'connected' ? 'bg-emerald-500' : 'bg-gray-400'}`} />
+            <Button
+              type="button"
+              size="icon"
+              className="rounded-full bg-red-500 hover:bg-red-600 text-white w-12 h-12"
+              onClick={() => setVoiceActive(false)}
+              title="Disconnect"
+            >
+              <X className="w-6 h-6" />
+            </Button>
+            <Mic className="w-6 h-6 text-blue-500" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Enhance homepage adaptiveness for smaller screens by hiding the left panel, expanding the right panel, and adding a responsive footer with connection controls.

---
<a href="https://cursor.com/background-agent?bcId=bc-941f350d-fc21-4f0e-b942-cb18e093b3c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-941f350d-fc21-4f0e-b942-cb18e093b3c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

