### PR TITLE
Study companion: Gemini Live voice, transcripts, and composer UI

### DIFF
--- a/src/components/students/study-companion/Composer.tsx
+++ b/src/components/students/study-companion/Composer.tsx
@@ -181,9 +181,6 @@ export function Composer({
           }}
         />
         <div className="flex shrink-0 items-center gap-1.5 pb-0.5 pr-0.5">
-          {voice.isStreaming ? (
-            <LiveWaveformStrip audioData={micAudioData} analyser={voice.getMicAnalyser?.() ?? null} active={waveformActive} />
-          ) : null}
           <Button
             type="button"
             variant={voice.isStreaming ? 'default' : 'outline'}
@@ -206,6 +203,9 @@ export function Composer({
           >
             {micBusy ? <Loader2 className="h-5 w-5 animate-spin" /> : voice.isStreaming ? <MicOff className="h-5 w-5" /> : <Mic className="h-5 w-5" />}
           </Button>
+          {voice.isStreaming ? (
+            <LiveWaveformStrip audioData={micAudioData} analyser={voice.getMicAnalyser?.() ?? null} active={waveformActive} />
+          ) : null}
           <Button
             type="button"
             size="icon"

--- a/src/components/students/study-companion/Composer.tsx
+++ b/src/components/students/study-companion/Composer.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { Send } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Loader2, Mic, MicOff, Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import type { StudyIntent, StudyMode } from './types';
+import { cn } from '@/lib/utils';
+import type { LessonContext, LiveTranscriptionPayload, UseAudioStreamingLiveOptions } from '@/hooks/useAudioStreaming';
+import { useAudioStreaming } from '@/hooks/useAudioStreaming';
+import type { StudyIntent, StudyMessage, StudyMode } from './types';
+import { LiveWaveformStrip } from './LiveWaveformStrip';
 
 interface ComposerProps {
   value: string;
@@ -11,8 +16,15 @@ interface ComposerProps {
   isLoading?: boolean;
   mode: StudyMode;
   intent: StudyIntent;
+  gradeLevel: string | null;
+  selectedLessonId: string | null;
+  lessonVoiceContext: LessonContext | undefined;
+  voiceLiveOptions: UseAudioStreamingLiveOptions;
+  voiceSessionReady: boolean;
   onChange: (value: string) => void;
   onSubmit: () => void;
+  onVoiceTranscript: (message: StudyMessage) => void;
+  onVoiceError?: (message: string) => void;
 }
 
 const modeCopy: Record<StudyMode, string> = {
@@ -30,30 +42,185 @@ const intentCopy: Record<StudyIntent, string> = {
   walkthrough: 'Paste the problem and where you got stuck...',
 };
 
-export function Composer({ value, disabled, isLoading, mode, intent, onChange, onSubmit }: ComposerProps) {
+export function Composer({
+  value,
+  disabled,
+  isLoading,
+  mode,
+  intent,
+  gradeLevel,
+  selectedLessonId,
+  lessonVoiceContext,
+  voiceLiveOptions,
+  voiceSessionReady,
+  onChange,
+  onSubmit,
+  onVoiceTranscript,
+  onVoiceError,
+}: ComposerProps) {
+  const [micAudioData, setMicAudioData] = useState(new Float32Array(0));
+  const [vadActive, setVadActive] = useState(false);
+  const userTranscriptRef = useRef('');
+  const assistantTranscriptRef = useRef('');
+
+  const voice = useAudioStreaming(null, lessonVoiceContext, voiceLiveOptions);
+
+  useEffect(() => {
+    voice.setSaveOnlySpeech?.(true);
+  }, [voice]);
+
+  useEffect(() => {
+    voice.setToolCallListener(() => {});
+  }, [voice]);
+
+  useEffect(() => {
+    voice.setOnAudioDataListener((data) => {
+      setMicAudioData(new Float32Array(data));
+    });
+  }, [voice]);
+
+  useEffect(() => {
+    voice.setOnVadStateListener?.((active) => {
+      setVadActive(active);
+    });
+  }, [voice]);
+
+  useEffect(() => {
+    voice.setOnTranscription?.((payload: LiveTranscriptionPayload) => {
+      if (payload.role === 'user') {
+        if (payload.text) userTranscriptRef.current = payload.text;
+        if (payload.finished) {
+          const content = userTranscriptRef.current.trim();
+          userTranscriptRef.current = '';
+          if (content) {
+            onVoiceTranscript({
+              role: 'user',
+              content,
+              timestamp: new Date().toISOString(),
+              lessonId: selectedLessonId || undefined,
+              mode,
+              intent,
+            });
+          }
+        }
+        return;
+      }
+      if (payload.text) assistantTranscriptRef.current = payload.text;
+      if (payload.finished) {
+        const content = assistantTranscriptRef.current.trim();
+        assistantTranscriptRef.current = '';
+        if (content) {
+          onVoiceTranscript({
+            role: 'assistant',
+            content,
+            timestamp: new Date().toISOString(),
+            lessonId: selectedLessonId || undefined,
+            mode,
+            intent: 'general',
+          });
+        }
+      }
+    });
+  }, [voice, onVoiceTranscript, selectedLessonId, mode, intent]);
+
+  useEffect(() => {
+    if (!voice.error) return;
+    onVoiceError?.(voice.error);
+    voice.clearError();
+  }, [voice.error, voice.clearError, onVoiceError]);
+
+  const toggleMic = useCallback(async () => {
+    if (!voiceSessionReady) return;
+    try {
+      if (voice.isStreaming) voice.stopStreaming();
+      else await voice.startStreaming();
+    } catch (e) {
+      onVoiceError?.(e instanceof Error ? e.message : 'Voice connection failed');
+    }
+  }, [voice, voiceSessionReady, onVoiceError]);
+
+  const handleSend = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    if (voice.isStreaming && voice.connectionStatus === 'connected') {
+      voice.sendText(trimmed);
+      onChange('');
+      return;
+    }
+    onSubmit();
+  };
+
+  const sendDisabled = disabled || isLoading || (!voice.isStreaming && !value.trim());
+  const micBusy = voice.connectionStatus === 'connecting';
+  const waveformActive = voice.isStreaming && (vadActive || voice.isSpeaking || voice.connectionStatus === 'connected');
+
   return (
     <div className="space-y-2">
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
+      <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
         <span>{modeCopy[mode]}</span>
         {intent !== 'general' && <span className="capitalize">{intent}</span>}
       </div>
-      <div className="flex gap-4">
+      <div
+        className={cn(
+          'flex items-end gap-2 rounded-2xl border border-border/70 bg-muted/25 p-2 shadow-sm backdrop-blur-sm transition-[box-shadow,border-color] focus-within:border-primary/35 focus-within:shadow-md dark:bg-muted/15',
+          voice.isStreaming && 'border-primary/30',
+        )}
+      >
         <Textarea
           value={value}
           onChange={(event) => onChange(event.target.value)}
           placeholder={intentCopy[intent]}
-          className="min-h-[60px]"
+          disabled={disabled || isLoading}
+          rows={1}
+          className="max-h-[200px] min-h-[52px] flex-1 resize-none rounded-xl border-0 bg-transparent px-3 py-2.5 text-[15px] leading-relaxed shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
           onKeyDown={(event) => {
             if (event.key === 'Enter' && !event.shiftKey) {
               event.preventDefault();
-              onSubmit();
+              handleSend();
             }
           }}
         />
-        <Button onClick={onSubmit} disabled={disabled || isLoading || !value.trim()} className="h-auto">
-          <Send className="h-4 w-4" />
-        </Button>
+        <div className="flex shrink-0 items-center gap-1.5 pb-0.5 pr-0.5">
+          {voice.isStreaming ? (
+            <LiveWaveformStrip audioData={micAudioData} analyser={voice.getMicAnalyser?.() ?? null} active={waveformActive} />
+          ) : null}
+          <Button
+            type="button"
+            variant={voice.isStreaming ? 'default' : 'outline'}
+            size="icon"
+            disabled={disabled || isLoading || !voiceSessionReady || micBusy}
+            className={cn(
+              'h-11 w-11 shrink-0 rounded-full border-border/80 shadow-sm transition-transform active:scale-95',
+              voice.isStreaming && 'bg-primary text-primary-foreground',
+            )}
+            aria-pressed={voice.isStreaming}
+            aria-label={voice.isStreaming ? 'Turn off microphone' : 'Turn on microphone'}
+            title={
+              !voiceSessionReady
+                ? 'Start or open a study session to use voice'
+                : voice.isStreaming
+                  ? 'Stop voice'
+                  : 'Start voice'
+            }
+            onClick={() => void toggleMic()}
+          >
+            {micBusy ? <Loader2 className="h-5 w-5 animate-spin" /> : voice.isStreaming ? <MicOff className="h-5 w-5" /> : <Mic className="h-5 w-5" />}
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            disabled={sendDisabled}
+            className="h-11 w-11 shrink-0 rounded-full shadow-sm"
+            aria-label="Send message"
+            onClick={handleSend}
+          >
+            <Send className="h-5 w-5" />
+          </Button>
+        </div>
       </div>
+      {voice.isStreaming && voice.connectionStatus === 'connected' ? (
+        <p className="text-xs text-muted-foreground">Voice is on — speak naturally or type and send to add text to the live session.</p>
+      ) : null}
     </div>
   );
 }

--- a/src/components/students/study-companion/LiveWaveformStrip.tsx
+++ b/src/components/students/study-companion/LiveWaveformStrip.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import AudioVisualizer from '@/components/voice/AudioVisualizer';
+
+type LiveWaveformStripProps = {
+  audioData: Float32Array;
+  analyser: AnalyserNode | null;
+  active: boolean;
+};
+
+export function LiveWaveformStrip({ audioData, analyser, active }: LiveWaveformStripProps) {
+  return (
+    <div
+      className="relative h-11 w-[5.5rem] shrink-0 overflow-hidden rounded-full border border-border/60 bg-background/80 shadow-inner"
+      aria-hidden
+    >
+      <AudioVisualizer audioData={audioData} isActive={active} analyser={analyser} variant="mic" />
+    </div>
+  );
+}

--- a/src/components/students/study-companion/StudyCompanionShell.tsx
+++ b/src/components/students/study-companion/StudyCompanionShell.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import type { MouseEvent } from 'react';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertTriangle, BookOpen, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, GraduationCap, Loader2, Plus, Sparkles } from 'lucide-react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { SupabaseSessionContext } from '@/components/providers/SupabaseAuthProvider';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useToast } from '@/components/ui/use-toast';
+import type { LessonContext } from '@/hooks/useAudioStreaming';
 import { ChatHistoryPanel } from './ChatHistoryPanel';
 import { ChatThread } from './ChatThread';
 import { Composer } from './Composer';
@@ -65,6 +66,35 @@ export function StudyCompanionShell() {
   const [showQuickActions, setShowQuickActions] = useState(true);
   const [outageNotice, setOutageNotice] = useState<OutageNotice | null>(null);
   const [localSendCount, setLocalSendCount] = useState(0);
+  const chatIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    chatIdRef.current = currentChatId;
+  }, [currentChatId]);
+
+  const lessonVoiceContext = useMemo((): LessonContext | undefined => {
+    if (!selectedLesson) return undefined;
+    const lesson = lessons.find((item) => getLessonId(item) === selectedLesson);
+    if (!lesson) return undefined;
+    return {
+      lessonId: selectedLesson,
+      title: lesson.title,
+      subject: lesson.subject,
+      gradeLevel: lesson.gradeLevel ?? lesson.gradelevel ?? gradeLevel ?? undefined,
+      objectives: lesson.objectives ?? undefined,
+      content: lesson.content ?? undefined,
+    };
+  }, [selectedLesson, lessons, gradeLevel]);
+
+  const voiceLiveOptions = useMemo(
+    () => ({
+      variant: 'studyCompanion' as const,
+      gradeLevel,
+      studyMode: mode,
+      studyIntent: intent,
+    }),
+    [gradeLevel, mode, intent],
+  );
 
   const selectedLessonTitle = useMemo(
     () => lessons.find((lesson) => getLessonId(lesson) === selectedLesson)?.title,
@@ -360,6 +390,26 @@ export function StudyCompanionShell() {
     }
   };
 
+  const handleVoiceTranscript = (msg: StudyMessage) => {
+    setMessages((prev) => {
+      const next = [...prev, msg];
+      const id = chatIdRef.current;
+      if (id) {
+        void fetch(`/api/students/chats/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ messages: next }),
+        })
+          .then((response) => {
+            if (response.ok) void refreshChatHistory();
+          })
+          .catch(() => {});
+      }
+      return next;
+    });
+    setLocalSendCount((current) => current + 1);
+  };
+
   if (!session) {
     return (
       <DashboardLayout>
@@ -512,8 +562,21 @@ export function StudyCompanionShell() {
                 isLoading={isLoading}
                 mode={mode}
                 intent={intent}
+                gradeLevel={gradeLevel}
+                selectedLessonId={selectedLesson}
+                lessonVoiceContext={lessonVoiceContext}
+                voiceLiveOptions={voiceLiveOptions}
+                voiceSessionReady={Boolean(currentChatId && messages.length > 0)}
                 onChange={setInput}
                 onSubmit={sendMessage}
+                onVoiceTranscript={handleVoiceTranscript}
+                onVoiceError={(description) =>
+                  toast({
+                    title: 'Voice',
+                    description,
+                    variant: 'destructive',
+                  })
+                }
               />
               {!gradeLevel && (
                 <p className="text-sm text-muted-foreground">

--- a/src/components/students/study-companion/types.ts
+++ b/src/components/students/study-companion/types.ts
@@ -51,6 +51,8 @@ export interface Lesson {
   subject: string;
   gradeLevel?: string;
   gradelevel?: string;
+  objectives?: string | null;
+  content?: string | null;
 }
 
 export const getChatId = (chat: Pick<ChatHistory, '_id' | 'id'>) => chat._id ?? chat.id ?? '';

--- a/src/hooks/useAudioStreaming.ts
+++ b/src/hooks/useAudioStreaming.ts
@@ -1,6 +1,20 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { GoogleGenAI, MediaResolution, Modality, LiveServerMessage, Type, Behavior, FunctionResponseScheduling, StartSensitivity, EndSensitivity } from '@google/genai';
+import { buildStudyCompanionLiveVoiceSystemPrompt, type StudyIntent, type StudyMode } from '@/lib/study-companion';
 import { EUREKA_TUTOR_SYSTEM_PROMPT } from '@/lib/tutor-system-prompt';
+
+export type UseAudioStreamingLiveOptions = {
+    variant?: 'tutor' | 'studyCompanion';
+    gradeLevel?: string | null;
+    studyMode?: StudyMode;
+    studyIntent?: StudyIntent;
+};
+
+export type LiveTranscriptionPayload = {
+    role: 'user' | 'assistant';
+    text: string;
+    finished: boolean;
+};
 
 interface AudioStreamingState {
     isStreaming: boolean;
@@ -30,6 +44,7 @@ interface AudioStreamingActions {
     submitFeedback: (feedback: any) => Promise<void>;
     setSaveOnlySpeech?: (enabled: boolean) => void;
     setOnVadStateListener?: (cb: (active: boolean, rms: number) => void) => void;
+    setOnTranscription?: (cb: ((payload: LiveTranscriptionPayload) => void) | null) => void;
 }
 
 export interface LessonContext {
@@ -43,7 +58,11 @@ export interface LessonContext {
 
 const systemPrompt = EUREKA_TUTOR_SYSTEM_PROMPT;
 
-export function useAudioStreaming(topic?: string | null, lessonContext?: LessonContext): AudioStreamingState & AudioStreamingActions {
+export function useAudioStreaming(
+    topic?: string | null,
+    lessonContext?: LessonContext,
+    liveOptions?: UseAudioStreamingLiveOptions,
+): AudioStreamingState & AudioStreamingActions {
     const [isStreaming, setIsStreaming] = useState(false);
     const [audioUrl, setAudioUrl] = useState<string | null>(null);
     const [error, setError] = useState('');
@@ -69,6 +88,9 @@ export function useAudioStreaming(topic?: string | null, lessonContext?: LessonC
     const onVadStateListenerRef = useRef<((active: boolean, rms: number) => void) | null>(null);
     const lastAttemptTimeRef = useRef<number>(0);
     const geminiLiveSessionRef = useRef<any>(null);
+    const liveOptionsRef = useRef<UseAudioStreamingLiveOptions | undefined>(liveOptions);
+    liveOptionsRef.current = liveOptions;
+    const onTranscriptionListenerRef = useRef<((payload: LiveTranscriptionPayload) => void) | null>(null);
     // Session resumption
     const sessionResumptionHandleRef = useRef<string | null>(null);
     const isResumingSessionRef = useRef<boolean>(false);
@@ -435,12 +457,63 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
                 contextAddition = `\n\n### **Session Topic**\n\nThe learner has specifically requested to learn about: "${topic}"\n\nFocus your teaching on this topic. Tailor your explanations, visualizations, and questions to this subject matter.`;
             }
 
-            const finalSystemPrompt = systemPrompt + contextAddition;
+            const variant = liveOptionsRef.current?.variant ?? 'tutor';
+            const isStudyCompanion = variant === 'studyCompanion';
+
+            let finalSystemPrompt: string;
+            if (isStudyCompanion) {
+                const gl = liveOptionsRef.current?.gradeLevel?.trim() || 'the learner';
+                const sm = liveOptionsRef.current?.studyMode ?? 'companion';
+                const si = liveOptionsRef.current?.studyIntent ?? 'general';
+                const lessonHint =
+                    lessonContext?.title && lessonContext.title.trim().length > 0
+                        ? {
+                              title: lessonContext.title,
+                              subject: lessonContext.subject || 'general',
+                              objectives: lessonContext.objectives ?? null,
+                              content: lessonContext.content ?? null,
+                          }
+                        : undefined;
+                finalSystemPrompt = buildStudyCompanionLiveVoiceSystemPrompt(gl, sm, si, lessonHint);
+            } else {
+                finalSystemPrompt = systemPrompt + contextAddition;
+            }
+
+            const tutorTools = [
+                { googleSearch: {} },
+                {
+                    functionDeclarations: [{
+                        name: 'generate_visualization_description',
+                        description: 'Generates a visual aid for the learner. Call whenever you would show, draw, or demonstrate something.',
+                        parameters: {
+                            type: 'object',
+                            properties: {
+                                task_description: {
+                                    type: 'string',
+                                    description: 'A detailed description of the visual to generate. Specify the type (illustration, interactive demo, visual quiz, title card), layout, interactions, labels, and include image URLs in markdown syntax where relevant.'
+                                }
+                            },
+                            required: ['task_description']
+                        }
+                    }, {
+                        name: 'set_topic',
+                        description: 'Sets or updates the current discussion topic. Call on new main topic or topic change. Do not call this function on subtopics.',
+                        parameters: {
+                            type: 'object',
+                            properties: {
+                                topic: {
+                                    type: 'string',
+                                    description: 'A concise 3–8 word title describing the current main topic.'
+                                }
+                            },
+                            required: ['topic']
+                        }
+                    }]
+                }
+            ];
 
             const connectConfig: any = {
                 model: process.env.NEXT_PUBLIC_GEMINI_LIVE_MODEL,
-                // Configuration is locked server-side via ephemeral token liveConnectConstraints
-                // Session resumption
                 config: {
                     responseModalities: [Modality.AUDIO],
                     proactivity: { proactiveAudio: true },
@@ -463,38 +536,10 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
                     sessionResumption: {
                         handle: sessionResumptionHandleRef.current || undefined
                     },
-                    tools: [
-                        { googleSearch: {} },
-                        {
-                            functionDeclarations: [{
-                                name: 'generate_visualization_description',
-                                description: 'Generates a visual aid for the learner. Call whenever you would show, draw, or demonstrate something.',
-                                parameters: {
-                                    type: 'object',
-                                    properties: {
-                                        task_description: {
-                                            type: 'string',
-                                            description: 'A detailed description of the visual to generate. Specify the type (illustration, interactive demo, visual quiz, title card), layout, interactions, labels, and include image URLs in markdown syntax where relevant.'
-                                        }
-                                    },
-                                    required: ['task_description']
-                                }
-                            }, {
-                                name: 'set_topic',
-                                description: 'Sets or updates the current discussion topic. Call on new main topic or topic change. Do not call this function on subtopics.',
-                                parameters: {
-                                    type: 'object',
-                                    properties: {
-                                        topic: {
-                                            type: 'string',
-                                            description: 'A concise 3–8 word title describing the current main topic.'
-                                        }
-                                    },
-                                    required: ['topic']
-                                }
-                            }]
-                        }
-                    ]
+                    tools: isStudyCompanion ? [{ googleSearch: {} }] : tutorTools,
+                    ...(isStudyCompanion
+                        ? { inputAudioTranscription: {}, outputAudioTranscription: {} }
+                        : {}),
                 },
                 callbacks: {
                     onopen: () => {
@@ -711,8 +756,11 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
                 }
             } catch { }
 
-            // Session resumption initial message
-            const initialMessage = sessionResumptionHandleRef.current ? 'Continue' : 'Hello';
+            const initialMessage = sessionResumptionHandleRef.current
+                ? 'Continue'
+                : isStudyCompanion
+                    ? 'The student connected for live voice study companion help. Greet them briefly and ask what they want to work on.'
+                    : 'Hello';
             geminiSession.sendRealtimeInput({ text: initialMessage });
 
         } catch (error: any) {
@@ -761,6 +809,24 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
                     analyserRef.current = null;
                     nextPlaybackTimeRef.current = 0;
                     continue;
+                }
+
+                const serverContent = message?.serverContent;
+                if (serverContent?.inputTranscription) {
+                    const tr = serverContent.inputTranscription;
+                    onTranscriptionListenerRef.current?.({
+                        role: 'user',
+                        text: tr.text ?? '',
+                        finished: Boolean(tr.finished),
+                    });
+                }
+                if (serverContent?.outputTranscription) {
+                    const tr = serverContent.outputTranscription;
+                    onTranscriptionListenerRef.current?.({
+                        role: 'assistant',
+                        text: tr.text ?? '',
+                        finished: Boolean(tr.finished),
+                    });
                 }
 
                 // Handle tool calls
@@ -1087,6 +1153,10 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
         saveOnlySpeechRef.current = enabled;
     }, []);
 
+    const setOnTranscription = useCallback((cb: ((payload: LiveTranscriptionPayload) => void) | null) => {
+        onTranscriptionListenerRef.current = cb;
+    }, []);
+
     const setOnVadStateListener = useCallback((cb: (active: boolean, rms: number) => void) => {
         onVadStateListenerRef.current = cb;
     }, []);
@@ -1124,6 +1194,7 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
         closeFeedbackForm,
         submitFeedback,
         setSaveOnlySpeech,
-        setOnVadStateListener
+        setOnVadStateListener,
+        setOnTranscription,
     };
 }

--- a/src/lib/study-companion.ts
+++ b/src/lib/study-companion.ts
@@ -349,6 +349,51 @@ export function buildVisualizationTaskDescription(args: {
     return parts.join('\n\n');
 }
 
+export function buildStudyCompanionLiveVoiceSystemPrompt(
+    gradeLevel: string,
+    mode: StudyMode,
+    intent: StudyIntent,
+    lesson?: { title: string; subject: string; objectives?: string | null; content?: string | null },
+): string {
+    let prompt = `You are the same study companion students use in text chat: you help grade ${gradeLevel} learners plan, practice, recall, reflect, and stay active. This conversation is voice-first. Speak in short, friendly bursts; do not read long walls of text aloud. Invite the learner to answer, try, or choose next steps regularly.
+
+Current mode: ${mode}
+Current learner intent: ${intent}`;
+
+    if (lesson) {
+        prompt += `\n\nYou are helping with the lesson "${lesson.title}" in the subject "${lesson.subject}".`;
+        if (lesson.objectives) {
+            prompt += `\nThe learning objectives for this lesson are:\n${lesson.objectives}`;
+        }
+        if (lesson.content) {
+            const raw = lesson.content.replace(/\u0000/g, '').trim();
+            const excerpt = raw.slice(0, 2000);
+            prompt += `\n\nRelevant lesson material (excerpt):\n${excerpt}${raw.length > 2000 ? '...' : ''}`;
+        }
+    }
+
+    prompt += `\n\nBehavior rules:
+- Prefer active learning over answer dumping.
+- Use the assistance ladder: clarify -> nudge -> hint -> partial step -> worked example -> direct solution.
+- In companion mode, start with a short question or activity unless the learner clearly needs instruction.
+- In tutor mode, explain clearly, check understanding, then give a similar practice task.
+- For homework-like requests, ask for the learner's attempt first or give a similar example before a final answer.
+- Refuse live cheating requests, then offer practice on the same concept.
+- Keep spoken answers plain and conversational; avoid long lists unless the learner asks for detail.
+- Do not describe or narrate UI elements; stay focused on learning.
+
+Intent guidance:
+- plan: create a realistic study plan and ask for missing goal or time information if needed.
+- quiz: ask one question at a time and wait for the learner's answer.
+- hint: give the smallest useful nudge, not a full answer.
+- explain: teach the concept clearly, then ask one check-for-understanding question.
+- walkthrough: guide step by step and pause for learner input.
+- review: identify weak spots and turn them into a short review queue.
+- general: follow the learner's goal unless they switch intent.`;
+
+    return prompt;
+}
+
 export const getSafeAIErrorCode = (error: unknown) => {
     if (!error || typeof error !== 'object') return 'provider_error';
     const maybeError = error as { code?: unknown; status?: unknown };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This integrates the same browser-side Gemini Live stack used by the interactive AI tutor into the student Study Companion (`/students/tutor`).

## Changes

- **Voice mode:** Rounded composer with a mic toggle next to Send. When live audio is active, a compact mic waveform appears between the mic and Send (reuses the existing `AudioVisualizer` with the mic analyser).
- **Gemini Live (study variant):** `useAudioStreaming` accepts optional `liveOptions` with `variant: 'studyCompanion'`. That mode uses a dedicated live system prompt aligned with the text study companion, enables `inputAudioTranscription` and `outputAudioTranscription`, and keeps tools limited to Google Search (no visualization tool calls that the study UI does not handle).
- **Transcripts:** Server `inputTranscription` / `outputTranscription` messages are surfaced via `setOnTranscription` and committed into the chat thread as normal user/assistant messages when each transcription finishes.
- **Persistence:** Finished voice transcripts are appended to React state and written with `PUT /api/students/chats/:id` alongside existing history refresh behavior.

## Testing

- `bun run build` passes.
- Manual browser pass: logged in as `student1@test.com`, opened Study Companion, confirmed modern composer with mic and send. Mic/waveform behavior depends on microphone permission; headless environments may not show the waveform.

## Notes

- Voice is enabled only after a session exists (`currentChatId` and at least one message), so the learner has a persisted thread before live audio starts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-170b32d6-0839-4404-8c20-ec184e891fbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-170b32d6-0839-4404-8c20-ec184e891fbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

