### PR TITLE
fix(lessons): harden objective learning kits

### DIFF
--- a/docs/superpowers/plans/2026-07-12-pr-13-0035-dml-template.sql
+++ b/docs/superpowers/plans/2026-07-12-pr-13-0035-dml-template.sql
@@ -1,0 +1,1398 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $verify_isolation$
+BEGIN
+  IF NOT pg_has_role(current_user, 'authenticated', 'MEMBER')
+    OR NOT pg_has_role(current_user, 'service_role', 'MEMBER') THEN
+    RAISE EXCEPTION
+      'Verification connection must be able to SET ROLE authenticated and service_role';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.content_jobs
+    WHERE status IN ('queued', 'running')
+  ) THEN
+    RAISE EXCEPTION
+      'Isolated verification clone contains globally claimable jobs';
+  END IF;
+
+  IF EXISTS (
+      SELECT 1 FROM public.users
+      WHERE id::text LIKE '10000000-0000-4000-8000-00000000000%'
+        OR email LIKE 'verify-%@example.invalid'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.teachers
+      WHERE id::text LIKE '20000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.organizations
+      WHERE id::text LIKE '30000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lessons
+      WHERE id::text LIKE '40000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_objectives
+      WHERE id::text LIKE '50000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.content_jobs
+      WHERE id::text LIKE '60000000-0000-4000-8000-00000000000%'
+        OR idempotency_key LIKE 'verify:%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_artifacts
+      WHERE id::text LIKE '80000000-0000-4000-8000-00000000000%'
+        OR series_id::text LIKE 'a0000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_assets
+      WHERE id::text LIKE '90000000-0000-4000-8000-00000000000%'
+        OR storage_path LIKE 'verification/%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_publications
+      WHERE id::text LIKE 'b0000000-0000-4000-8000-00000000000%'
+        OR content_hash LIKE 'verify:%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.organization_ai_usage
+      WHERE reference_id LIKE 'verify:%'
+    ) THEN
+    RAISE EXCEPTION 'Verification fixture namespace is not clean';
+  END IF;
+
+  IF to_regprocedure('public._verify_0035_assert(boolean,text)') IS NOT NULL
+    OR to_regprocedure('public._verify_0035_expect_error(text,text,text)') IS NOT NULL
+    OR to_regprocedure('public._verify_0035_assert_row_count(text,bigint,text)') IS NOT NULL
+    OR to_regprocedure('public._verify_0035_set_actor(uuid,text)') IS NOT NULL THEN
+    RAISE EXCEPTION 'Verification helper names already exist';
+  END IF;
+END;
+$verify_isolation$;
+
+CREATE FUNCTION public._verify_0035_assert(
+  p_condition boolean,
+  p_message text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $function$
+BEGIN
+  IF p_condition IS DISTINCT FROM true THEN
+    RAISE EXCEPTION '%', p_message;
+  END IF;
+END;
+$function$;
+
+CREATE FUNCTION public._verify_0035_expect_error(
+  p_sql text,
+  p_expected_state text,
+  p_expected_message text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $function$
+DECLARE
+  actual_state text;
+  actual_message text;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS
+      actual_state = RETURNED_SQLSTATE,
+      actual_message = MESSAGE_TEXT;
+    IF actual_state <> p_expected_state THEN
+      RAISE EXCEPTION
+        'Expected SQLSTATE %, got %: %',
+        p_expected_state,
+        actual_state,
+        actual_message;
+    END IF;
+    IF p_expected_message IS NOT NULL
+      AND actual_message <> p_expected_message THEN
+      RAISE EXCEPTION
+        'Expected message %, got %',
+        p_expected_message,
+        actual_message;
+    END IF;
+    RETURN;
+  END;
+  RAISE EXCEPTION
+    'Expected SQLSTATE %, but statement succeeded: %',
+    p_expected_state,
+    p_sql;
+END;
+$function$;
+
+CREATE FUNCTION public._verify_0035_assert_row_count(
+  p_sql text,
+  p_expected bigint,
+  p_message text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $function$
+DECLARE
+  affected bigint;
+BEGIN
+  EXECUTE p_sql;
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  IF affected <> p_expected THEN
+    RAISE EXCEPTION
+      '% (expected %, got %)',
+      p_message,
+      p_expected,
+      affected;
+  END IF;
+END;
+$function$;
+
+CREATE FUNCTION public._verify_0035_set_actor(
+  p_user_id uuid,
+  p_role text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $function$
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub', p_user_id::text, true);
+  PERFORM set_config('request.jwt.claim.role', p_role, true);
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('sub', p_user_id, 'role', p_role)::text,
+    true
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public._verify_0035_assert(boolean, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._verify_0035_expect_error(text, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._verify_0035_assert_row_count(text, bigint, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._verify_0035_set_actor(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._verify_0035_assert(boolean, text)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._verify_0035_expect_error(text, text, text)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._verify_0035_assert_row_count(text, bigint, text)
+  TO authenticated, service_role;
+
+INSERT INTO public.users (id, email, name, role)
+VALUES
+  ('10000000-0000-4000-8000-000000000001', 'verify-teacher@example.invalid', 'Verify Teacher', 'teacher'),
+  ('10000000-0000-4000-8000-000000000002', 'verify-admin@example.invalid', 'Verify Admin', 'admin'),
+  ('10000000-0000-4000-8000-000000000003', 'verify-other@example.invalid', 'Verify Other Teacher', 'teacher');
+
+INSERT INTO public.teachers (id, user_id, subjects, grades)
+VALUES
+  (
+    '20000000-0000-4000-8000-000000000001',
+    '10000000-0000-4000-8000-000000000001',
+    ARRAY[]::text[],
+    ARRAY[]::text[]
+  ),
+  (
+    '20000000-0000-4000-8000-000000000002',
+    '10000000-0000-4000-8000-000000000003',
+    ARRAY[]::text[],
+    ARRAY[]::text[]
+  );
+
+INSERT INTO public.organizations (id, name, owner_id)
+VALUES
+  ('30000000-0000-4000-8000-000000000001', 'Verify Source', '10000000-0000-4000-8000-000000000001'),
+  ('30000000-0000-4000-8000-000000000002', 'Verify Target', '10000000-0000-4000-8000-000000000001');
+
+UPDATE public.organization_members
+SET role = 'admin'
+WHERE organization_id = '30000000-0000-4000-8000-000000000002'
+  AND user_id = '10000000-0000-4000-8000-000000000001';
+
+INSERT INTO public.lessons (
+  id, title, subject, gradelevel, objectives, content,
+  teacher_id, organization_id, created_at, updated_at
+)
+VALUES
+  (
+    '40000000-0000-4000-8000-000000000001',
+    'Verify Lesson',
+    'Science',
+    '7',
+    ARRAY['Verify objective'],
+    'Verify content',
+    '20000000-0000-4000-8000-000000000001',
+    '30000000-0000-4000-8000-000000000001',
+    '2026-01-01T00:00:00Z',
+    '2026-01-01T00:00:00Z'
+  ),
+  (
+    '40000000-0000-4000-8000-000000000002',
+    'Delete Verification Lesson',
+    'Science',
+    '7',
+    ARRAY['Delete objective'],
+    'Disposable manager-delete fixture',
+    '20000000-0000-4000-8000-000000000001',
+    '30000000-0000-4000-8000-000000000001',
+    '2026-01-01T00:00:00Z',
+    '2026-01-01T00:00:00Z'
+  );
+
+INSERT INTO public.lesson_objectives (id, lesson_id, text, position, revision)
+VALUES
+  ('50000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000001', 'Verify objective', 0, 1),
+  ('50000000-0000-4000-8000-000000000002', '40000000-0000-4000-8000-000000000001', 'Cascade objective', 1, 1);
+
+INSERT INTO public.lesson_publications (
+  id, lesson_id, version, manifest, warnings, content_hash, published_by
+)
+VALUES (
+  'b0000000-0000-4000-8000-000000000001',
+  '40000000-0000-4000-8000-000000000001',
+  1,
+  '{}'::jsonb,
+  '[]'::jsonb,
+  'verify:publication',
+  '10000000-0000-4000-8000-000000000001'
+);
+
+INSERT INTO public.lesson_artifacts (
+  id, lesson_id, objective_id, series_id, version, objective_revision,
+  kind, status, position, payload, source, created_by, approved_by, approved_at
+)
+VALUES
+  (
+    '80000000-0000-4000-8000-000000000001',
+    '40000000-0000-4000-8000-000000000001',
+    '50000000-0000-4000-8000-000000000001',
+    'a0000000-0000-4000-8000-000000000001',
+    1, 1, 'structured_quiz', 'draft', 0,
+    '{"marker":"draft"}'::jsonb,
+    'teacher_authored',
+    '10000000-0000-4000-8000-000000000001',
+    NULL, NULL
+  ),
+  (
+    '80000000-0000-4000-8000-000000000002',
+    '40000000-0000-4000-8000-000000000001',
+    '50000000-0000-4000-8000-000000000001',
+    'a0000000-0000-4000-8000-000000000002',
+    1, 1, 'structured_quiz', 'rejected', 1,
+    '{"marker":"rejected"}'::jsonb,
+    'teacher_authored',
+    '10000000-0000-4000-8000-000000000001',
+    NULL, NULL
+  ),
+  (
+    '80000000-0000-4000-8000-000000000003',
+    '40000000-0000-4000-8000-000000000001',
+    '50000000-0000-4000-8000-000000000001',
+    'a0000000-0000-4000-8000-000000000003',
+    1, 1, 'structured_quiz', 'approved', 2,
+    '{"marker":"approved"}'::jsonb,
+    'teacher_authored',
+    '10000000-0000-4000-8000-000000000001',
+    '10000000-0000-4000-8000-000000000001', now()
+  ),
+  (
+    '80000000-0000-4000-8000-000000000004',
+    '40000000-0000-4000-8000-000000000001',
+    '50000000-0000-4000-8000-000000000002',
+    'a0000000-0000-4000-8000-000000000004',
+    1, 1, 'structured_quiz', 'draft', 0,
+    '{"marker":"cascade"}'::jsonb,
+    'teacher_authored',
+    '10000000-0000-4000-8000-000000000001',
+    NULL, NULL
+  );
+
+-- Enqueue one quota-attributed source-organization job.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'service_role'
+);
+SET LOCAL ROLE service_role;
+SELECT public.enqueue_content_jobs_with_usage(
+  '30000000-0000-4000-8000-000000000001',
+  '10000000-0000-4000-8000-000000000001',
+  '[{
+    "id":"60000000-0000-4000-8000-000000000001",
+    "batch_id":"70000000-0000-4000-8000-000000000001",
+    "lesson_id":"40000000-0000-4000-8000-000000000001",
+    "objective_id":"50000000-0000-4000-8000-000000000001",
+    "requested_by":"10000000-0000-4000-8000-000000000001",
+    "job_type":"generate_structured_quiz",
+    "idempotency_key":"verify:quota",
+    "input":{}
+  }]'::jsonb,
+  '[{
+    "category":"quiz_generation",
+    "quantity":1,
+    "referenceId":"verify:quota"
+  }]'::jsonb
+);
+RESET ROLE;
+
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+      AND status = 'queued'
+      AND organization_id = '30000000-0000-4000-8000-000000000001'
+  ),
+  'Quota enqueue did not persist one source-organization job'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.organization_ai_usage
+    WHERE organization_id = '30000000-0000-4000-8000-000000000001'
+      AND user_id = '10000000-0000-4000-8000-000000000001'
+      AND category = 'quiz_generation'
+      AND quantity = 1
+      AND reference_id = 'verify:quota'
+  ),
+  'Quota enqueue did not reserve exactly one source-organization usage row'
+);
+
+-- Authenticated clients retain own-job SELECT and lose all direct writes.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+  ),
+  'Authenticated teacher cannot read their own content job'
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    INSERT INTO public.content_jobs (
+      id, batch_id, lesson_id, objective_id, requested_by,
+      job_type, idempotency_key, input
+    ) VALUES (
+      '60000000-0000-4000-8000-000000000009',
+      '70000000-0000-4000-8000-000000000009',
+      '40000000-0000-4000-8000-000000000001',
+      '50000000-0000-4000-8000-000000000001',
+      '10000000-0000-4000-8000-000000000001',
+      'generate_structured_quiz',
+      'verify:forbidden',
+      '{}'::jsonb
+    )
+  $sql$,
+  '42501',
+  NULL
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.content_jobs SET status = 'cancelled'
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    DELETE FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+);
+RESET ROLE;
+
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000003',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 0 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+  ),
+  'A different teacher can read another teacher''s content job'
+);
+RESET ROLE;
+
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+      AND status = 'queued'
+  ),
+  'Denied authenticated writes changed the quota job'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 0 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000009'
+      OR idempotency_key = 'verify:forbidden'
+  ),
+  'Denied authenticated insert persisted a content job'
+);
+
+-- Fail the quota job through an owned, unexpired worker lease.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'service_role'
+);
+SET LOCAL ROLE service_role;
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1
+    FROM public.claim_content_jobs('verify-quota-initial', 1, 120)
+  ),
+  'Initial quota-job claim did not return exactly one job'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+      AND status = 'running'
+      AND lease_owner = 'verify-quota-initial'
+      AND attempt_count = 1
+      AND lease_expires_at > now()
+  ),
+  'Initial quota-job claim state is incorrect'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.content_jobs
+    SET status = 'failed',
+        error = 'Verification worker failure',
+        lease_owner = NULL,
+        lease_expires_at = NULL,
+        completed_at = now()
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+      AND status = 'running'
+      AND lease_owner = 'verify-quota-initial'
+      AND lease_expires_at > now()
+  $sql$,
+  1,
+  'Quota-job worker-failure transition failed'
+);
+
+-- A separate no-usage job proves queued cancel, retry, claim, and success.
+SELECT public.enqueue_content_jobs_with_usage(
+  '30000000-0000-4000-8000-000000000001',
+  '10000000-0000-4000-8000-000000000001',
+  '[{
+    "id":"60000000-0000-4000-8000-000000000002",
+    "batch_id":"70000000-0000-4000-8000-000000000002",
+    "lesson_id":"40000000-0000-4000-8000-000000000001",
+    "objective_id":"50000000-0000-4000-8000-000000000001",
+    "requested_by":"10000000-0000-4000-8000-000000000001",
+    "job_type":"generate_structured_quiz",
+    "idempotency_key":"verify:lifecycle",
+    "input":{}
+  }]'::jsonb,
+  '[]'::jsonb
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.content_jobs
+    SET status = 'cancelled', completed_at = now()
+    WHERE id = '60000000-0000-4000-8000-000000000002'
+      AND status = 'queued'
+  $sql$,
+  1,
+  'Queued lifecycle-job cancellation failed'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.content_jobs
+    SET status = 'queued',
+        attempt_count = 0,
+        error = NULL,
+        completed_at = NULL,
+        lease_owner = NULL,
+        lease_expires_at = NULL
+    WHERE id = '60000000-0000-4000-8000-000000000002'
+      AND status = 'cancelled'
+  $sql$,
+  1,
+  'Cancelled lifecycle-job retry failed'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1
+    FROM public.claim_content_jobs('verify-lifecycle', 1, 120)
+  ),
+  'Retried lifecycle-job claim did not return exactly one job'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.content_jobs
+    SET status = 'succeeded',
+        output = '{"verified":true}'::jsonb,
+        lease_owner = NULL,
+        lease_expires_at = NULL,
+        completed_at = now()
+    WHERE id = '60000000-0000-4000-8000-000000000002'
+      AND status = 'running'
+      AND lease_owner = 'verify-lifecycle'
+      AND lease_expires_at > now()
+  $sql$,
+  1,
+  'Lifecycle-job worker-success transition failed'
+);
+RESET ROLE;
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000002'
+      AND status = 'succeeded'
+      AND lease_owner IS NULL
+      AND lease_expires_at IS NULL
+  ),
+  'Lifecycle-job success state is incorrect'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.organization_ai_usage
+    WHERE reference_id = 'verify:quota'
+  ),
+  'No-usage lifecycle retry changed quota reservations'
+);
+
+-- Draft and rejected artifacts update/delete; approved artifacts remain immutable.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'service_role'
+);
+SET LOCAL ROLE service_role;
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lesson_artifacts
+    SET payload = '{"marker":"draft-updated"}'::jsonb
+    WHERE id = '80000000-0000-4000-8000-000000000001'
+  $sql$,
+  1,
+  'Draft update did not affect one row'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lesson_artifacts
+    SET payload = '{"marker":"rejected-updated"}'::jsonb
+    WHERE id = '80000000-0000-4000-8000-000000000002'
+  $sql$,
+  1,
+  'Rejected update did not affect one row'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 2 FROM public.lesson_artifacts
+    WHERE (id = '80000000-0000-4000-8000-000000000001'
+        AND payload = '{"marker":"draft-updated"}'::jsonb)
+       OR (id = '80000000-0000-4000-8000-000000000002'
+        AND payload = '{"marker":"rejected-updated"}'::jsonb)
+  ),
+  'Draft or rejected artifact update did not persist'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    DELETE FROM public.lesson_artifacts
+    WHERE id IN (
+      '80000000-0000-4000-8000-000000000001',
+      '80000000-0000-4000-8000-000000000002'
+    )
+  $sql$,
+  2,
+  'Draft/rejected delete did not affect exactly two rows'
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lesson_artifacts
+    SET payload = '{"mutated":true}'::jsonb
+    WHERE id = '80000000-0000-4000-8000-000000000003'
+  $sql$,
+  'P0001',
+  'Approved lesson artifacts are immutable; create a new version'
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    DELETE FROM public.lesson_artifacts
+    WHERE id = '80000000-0000-4000-8000-000000000003'
+  $sql$,
+  'P0001',
+  'Approved lesson artifacts are immutable; create a new version'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    DELETE FROM public.lesson_objectives
+    WHERE id = '50000000-0000-4000-8000-000000000002'
+  $sql$,
+  1,
+  'Cascade-only objective delete failed'
+);
+RESET ROLE;
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 0 FROM public.lesson_artifacts
+    WHERE id IN (
+      '80000000-0000-4000-8000-000000000001',
+      '80000000-0000-4000-8000-000000000002',
+      '80000000-0000-4000-8000-000000000004'
+    )
+  ),
+  'Draft, rejected, or cascade artifact remains'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.lesson_artifacts
+    WHERE id = '80000000-0000-4000-8000-000000000003'
+      AND payload = '{"marker":"approved"}'::jsonb
+  ),
+  'Approved artifact changed after rejected mutations'
+);
+
+-- Teacher allowlist and successful owner/admin transfers.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lessons
+    SET title = 'Teacher-updated lesson',
+        subject = 'Updated science',
+        gradelevel = '8',
+        objectives = ARRAY['Updated objective'],
+        content = 'Teacher-updated content',
+        organization_id = '30000000-0000-4000-8000-000000000001',
+        updated_at = now()
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  1,
+  'Teacher allowlisted update or same-organization no-op failed'
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    INSERT INTO public.lessons (
+      id, title, subject, gradelevel, objectives, content,
+      teacher_id, organization_id, created_at, updated_at
+    ) VALUES (
+      '40000000-0000-4000-8000-000000000009',
+      'Forbidden direct insert',
+      'Science',
+      '8',
+      ARRAY['Forbidden objective'],
+      'Forbidden content',
+      '20000000-0000-4000-8000-000000000001',
+      '30000000-0000-4000-8000-000000000001',
+      now(),
+      now()
+    )
+  $sql$,
+  '42501',
+  NULL
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    DELETE FROM public.lessons
+    WHERE id = '40000000-0000-4000-8000-000000000002'
+  $sql$,
+  1,
+  'Owning teacher could not delete a disposable managed lesson'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  1,
+  'Source-owner to target-admin transfer failed'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000001'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  1,
+  'Current-admin to target-owner transfer failed'
+);
+RESET ROLE;
+
+-- Current/source membership: missing, inactive, and member all fail.
+DELETE FROM public.organization_members
+WHERE organization_id = '30000000-0000-4000-8000-000000000001'
+  AND user_id = '10000000-0000-4000-8000-000000000001';
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  'Active owner or admin membership in current organization is required'
+);
+RESET ROLE;
+
+INSERT INTO public.organization_members (
+  organization_id, user_id, role, is_active
+) VALUES (
+  '30000000-0000-4000-8000-000000000001',
+  '10000000-0000-4000-8000-000000000001',
+  'owner',
+  false
+);
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  'Active owner or admin membership in current organization is required'
+);
+RESET ROLE;
+
+UPDATE public.organization_members
+SET role = 'member', is_active = true
+WHERE organization_id = '30000000-0000-4000-8000-000000000001'
+  AND user_id = '10000000-0000-4000-8000-000000000001';
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  'Active owner or admin membership in current organization is required'
+);
+RESET ROLE;
+UPDATE public.organization_members
+SET role = 'owner', is_active = true
+WHERE organization_id = '30000000-0000-4000-8000-000000000001'
+  AND user_id = '10000000-0000-4000-8000-000000000001';
+
+-- Target membership: missing, inactive, and member all fail.
+DELETE FROM public.organization_members
+WHERE organization_id = '30000000-0000-4000-8000-000000000002'
+  AND user_id = '10000000-0000-4000-8000-000000000001';
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  'Active owner or admin membership in target organization is required'
+);
+RESET ROLE;
+
+INSERT INTO public.organization_members (
+  organization_id, user_id, role, is_active
+) VALUES (
+  '30000000-0000-4000-8000-000000000002',
+  '10000000-0000-4000-8000-000000000001',
+  'admin',
+  false
+);
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  'Active owner or admin membership in target organization is required'
+);
+RESET ROLE;
+
+UPDATE public.organization_members
+SET role = 'member', is_active = true
+WHERE organization_id = '30000000-0000-4000-8000-000000000002'
+  AND user_id = '10000000-0000-4000-8000-000000000001';
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  'Active owner or admin membership in target organization is required'
+);
+RESET ROLE;
+UPDATE public.organization_members
+SET role = 'admin', is_active = true
+WHERE organization_id = '30000000-0000-4000-8000-000000000002'
+  AND user_id = '10000000-0000-4000-8000-000000000001';
+
+-- Explicit null and protected-column writes fail for the owning teacher.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons SET organization_id = NULL
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  'Lesson organization cannot be cleared'
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET teacher_id = '20000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET current_publication_id = 'b0000000-0000-4000-8000-000000000001'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET id = '40000000-0000-4000-8000-000000000009'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons SET created_at = now()
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET teacher = '10000000-0000-4000-8000-000000000003'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+)
+WHERE EXISTS (
+  SELECT 1 FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'lessons'
+    AND column_name = 'teacher'
+);
+RESET ROLE;
+
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.lessons
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+      AND teacher_id = '20000000-0000-4000-8000-000000000001'
+      AND current_publication_id IS NULL
+      AND created_at = '2026-01-01T00:00:00Z'::timestamptz
+      AND organization_id = '30000000-0000-4000-8000-000000000001'
+  ),
+  'Teacher protected-field attempts changed the lesson'
+);
+DO $verify_teacher_legacy_unchanged$
+DECLARE
+  legacy_teacher uuid;
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'lessons'
+      AND column_name = 'teacher'
+  ) THEN
+    EXECUTE 'SELECT teacher FROM public.lessons WHERE id = $1'
+      INTO legacy_teacher
+      USING '40000000-0000-4000-8000-000000000001'::uuid;
+    IF legacy_teacher IS NOT NULL THEN
+      RAISE EXCEPTION 'Teacher changed the protected legacy teacher column';
+    END IF;
+  END IF;
+END;
+$verify_teacher_legacy_unchanged$;
+
+-- A different teacher cannot update a row they do not manage.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000003',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lessons SET title = 'Forbidden non-owner update'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  0,
+  'Non-owner teacher updated a lesson'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    DELETE FROM public.lessons
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  0,
+  'Non-owner teacher deleted a lesson'
+);
+RESET ROLE;
+
+-- Global admins bypass membership, but not the protected-column allowlist.
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 0 FROM public.organization_members
+    WHERE user_id = '10000000-0000-4000-8000-000000000002'
+  ),
+  'Global admin unexpectedly has organization membership'
+);
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000002',
+  'authenticated'
+);
+SET LOCAL ROLE authenticated;
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  1,
+  'Global-admin organization transfer failed'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000001',
+        title = 'Admin-updated lesson',
+        content = 'Admin-updated content',
+        updated_at = now()
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  1,
+  'Global-admin reset or allowlisted update failed'
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET teacher_id = '20000000-0000-4000-8000-000000000002'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET current_publication_id = 'b0000000-0000-4000-8000-000000000001'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+);
+SELECT public._verify_0035_expect_error(
+  $sql$
+    UPDATE public.lessons
+    SET teacher = '10000000-0000-4000-8000-000000000003'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  '42501',
+  NULL
+)
+WHERE EXISTS (
+  SELECT 1 FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'lessons'
+    AND column_name = 'teacher'
+);
+RESET ROLE;
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.lessons
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+      AND teacher_id = '20000000-0000-4000-8000-000000000001'
+      AND current_publication_id IS NULL
+      AND organization_id = '30000000-0000-4000-8000-000000000001'
+      AND title = 'Admin-updated lesson'
+  ),
+  'Global-admin protected-field attempts changed the lesson'
+);
+DO $verify_admin_legacy_unchanged$
+DECLARE
+  legacy_teacher uuid;
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'lessons'
+      AND column_name = 'teacher'
+  ) THEN
+    EXECUTE 'SELECT teacher FROM public.lessons WHERE id = $1'
+      INTO legacy_teacher
+      USING '40000000-0000-4000-8000-000000000001'::uuid;
+    IF legacy_teacher IS NOT NULL THEN
+      RAISE EXCEPTION 'Global admin changed the protected legacy teacher column';
+    END IF;
+  END IF;
+END;
+$verify_admin_legacy_unchanged$;
+
+-- Service role explicitly maintains protected fields and bypasses the org guard.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'service_role'
+);
+SET LOCAL ROLE service_role;
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lessons
+    SET organization_id = '30000000-0000-4000-8000-000000000002',
+        teacher_id = '20000000-0000-4000-8000-000000000002',
+        current_publication_id = 'b0000000-0000-4000-8000-000000000001'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  1,
+  'Service-role protected-field maintenance failed'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lessons
+    SET teacher = '10000000-0000-4000-8000-000000000003'
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  1,
+  'Service-role legacy-teacher maintenance failed'
+)
+WHERE EXISTS (
+  SELECT 1 FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'lessons'
+    AND column_name = 'teacher'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.lessons SET organization_id = NULL
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+  $sql$,
+  1,
+  'Service-role null-organization maintenance failed'
+);
+RESET ROLE;
+
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.lessons
+    WHERE id = '40000000-0000-4000-8000-000000000001'
+      AND teacher_id = '20000000-0000-4000-8000-000000000002'
+      AND current_publication_id = 'b0000000-0000-4000-8000-000000000001'
+      AND organization_id IS NULL
+  ),
+  'Service-role maintenance state did not persist'
+);
+DO $verify_service_legacy_teacher$
+DECLARE
+  legacy_teacher uuid;
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'lessons'
+      AND column_name = 'teacher'
+  ) THEN
+    EXECUTE 'SELECT teacher FROM public.lessons WHERE id = $1'
+      INTO legacy_teacher
+      USING '40000000-0000-4000-8000-000000000001'::uuid;
+    IF legacy_teacher IS DISTINCT FROM
+      '10000000-0000-4000-8000-000000000003'::uuid THEN
+      RAISE EXCEPTION 'Service role did not update legacy teacher';
+    END IF;
+  END IF;
+END;
+$verify_service_legacy_teacher$;
+
+-- Retry the original quota job after the lesson's real reassignment.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'service_role'
+);
+SET LOCAL ROLE service_role;
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.content_jobs
+    SET status = 'queued',
+        attempt_count = 0,
+        error = NULL,
+        completed_at = NULL,
+        lease_owner = NULL,
+        lease_expires_at = NULL
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+      AND status = 'failed'
+  $sql$,
+  1,
+  'Original quota-job retry failed'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1
+    FROM public.claim_content_jobs('verify-quota-retry', 1, 120)
+  ),
+  'Retried quota-job claim did not return exactly one job'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+      AND status = 'running'
+      AND lease_owner = 'verify-quota-retry'
+      AND attempt_count = 1
+      AND lease_expires_at > now()
+  ),
+  'Retried quota-job claim state is incorrect'
+);
+SELECT public._verify_0035_assert_row_count(
+  $sql$
+    UPDATE public.content_jobs
+    SET status = 'succeeded',
+        output = '{"verified":true}'::jsonb,
+        lease_owner = NULL,
+        lease_expires_at = NULL,
+        completed_at = now()
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+      AND status = 'running'
+      AND lease_owner = 'verify-quota-retry'
+      AND lease_expires_at > now()
+  $sql$,
+  1,
+  'Retried quota-job worker-success transition failed'
+);
+RESET ROLE;
+
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000001'
+      AND status = 'succeeded'
+      AND organization_id = '30000000-0000-4000-8000-000000000001'
+      AND lease_owner IS NULL
+      AND lease_expires_at IS NULL
+  ),
+  'Lesson reassignment changed the original job organization'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.organization_ai_usage
+    WHERE organization_id = '30000000-0000-4000-8000-000000000001'
+      AND user_id = '10000000-0000-4000-8000-000000000001'
+      AND category = 'quiz_generation'
+      AND quantity = 1
+      AND reference_id = 'verify:quota'
+  ),
+  'Original source quota reservation changed after reassignment or retry'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 0 FROM public.organization_ai_usage
+    WHERE organization_id = '30000000-0000-4000-8000-000000000002'
+      AND reference_id = 'verify:quota'
+  ),
+  'Retry created a target-organization quota reservation'
+);
+
+-- Upload RPC returns and persists the expected asset, artifact, job, and usage.
+SELECT public._verify_0035_set_actor(
+  '10000000-0000-4000-8000-000000000001',
+  'service_role'
+);
+SET LOCAL ROLE service_role;
+WITH uploaded AS (
+  SELECT public.create_uploaded_lesson_artifact(
+    '30000000-0000-4000-8000-000000000001',
+    '10000000-0000-4000-8000-000000000001',
+    'verify:upload',
+    '{
+      "id":"90000000-0000-4000-8000-000000000001",
+      "lesson_id":"40000000-0000-4000-8000-000000000001",
+      "objective_id":"50000000-0000-4000-8000-000000000001",
+      "asset_type":"uploaded_media",
+      "storage_bucket":"lesson-assets",
+      "storage_path":"verification/90000000-0000-4000-8000-000000000001",
+      "mime_type":"image/png",
+      "byte_size":1,
+      "checksum_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "original_filename":"verification.png",
+      "alt_text":"Verification image",
+      "caption":"",
+      "processing_status":"ready"
+    }'::jsonb,
+    '{
+      "id":"80000000-0000-4000-8000-000000000005",
+      "lesson_id":"40000000-0000-4000-8000-000000000001",
+      "objective_id":"50000000-0000-4000-8000-000000000001",
+      "objective_revision":1,
+      "kind":"uploaded_media",
+      "position":9,
+      "payload":{"assetId":"90000000-0000-4000-8000-000000000001"}
+    }'::jsonb,
+    '{
+      "id":"60000000-0000-4000-8000-000000000003",
+      "batch_id":"70000000-0000-4000-8000-000000000003",
+      "lesson_id":"40000000-0000-4000-8000-000000000001",
+      "objective_id":"50000000-0000-4000-8000-000000000001",
+      "job_type":"extract_media",
+      "idempotency_key":"verify:upload-job",
+      "input":{}
+    }'::jsonb
+  ) AS payload
+)
+SELECT public._verify_0035_assert(
+  payload #>> '{asset,id}' = '90000000-0000-4000-8000-000000000001'
+    AND payload #>> '{artifact,id}' = '80000000-0000-4000-8000-000000000005'
+    AND payload #>> '{job,id}' = '60000000-0000-4000-8000-000000000003',
+  'Upload RPC returned incorrect identifiers'
+)
+FROM uploaded;
+RESET ROLE;
+
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.lesson_assets
+    WHERE id = '90000000-0000-4000-8000-000000000001'
+      AND processing_status = 'ready'
+  ),
+  'Upload asset was not persisted'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.lesson_artifacts
+    WHERE id = '80000000-0000-4000-8000-000000000005'
+      AND payload ->> 'assetId' = '90000000-0000-4000-8000-000000000001'
+      AND source = 'teacher_uploaded'
+  ),
+  'Upload artifact was not persisted'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.content_jobs
+    WHERE id = '60000000-0000-4000-8000-000000000003'
+      AND asset_id = '90000000-0000-4000-8000-000000000001'
+      AND artifact_id = '80000000-0000-4000-8000-000000000005'
+      AND organization_id = '30000000-0000-4000-8000-000000000001'
+      AND status = 'queued'
+  ),
+  'Upload job links were not persisted'
+);
+SELECT public._verify_0035_assert(
+  (
+    SELECT count(*) = 1 FROM public.organization_ai_usage
+    WHERE organization_id = '30000000-0000-4000-8000-000000000001'
+      AND user_id = '10000000-0000-4000-8000-000000000001'
+      AND category = 'media_bytes'
+      AND quantity = 1
+      AND reference_id = 'verify:upload'
+  ),
+  'Upload RPC did not reserve source-organization media usage'
+);
+
+RESET ROLE;
+ROLLBACK;
+
+-- Prove the main transaction left neither helpers nor fixtures.
+BEGIN READ ONLY;
+DO $verify_rollback$
+BEGIN
+  IF to_regprocedure('public._verify_0035_assert(boolean,text)') IS NOT NULL
+    OR to_regprocedure('public._verify_0035_expect_error(text,text,text)') IS NOT NULL
+    OR to_regprocedure('public._verify_0035_assert_row_count(text,bigint,text)') IS NOT NULL
+    OR to_regprocedure('public._verify_0035_set_actor(uuid,text)') IS NOT NULL
+    OR EXISTS (
+      SELECT 1 FROM public.users
+      WHERE id::text LIKE '10000000-0000-4000-8000-00000000000%'
+        OR email LIKE 'verify-%@example.invalid'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lessons
+      WHERE id::text LIKE '40000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.content_jobs
+      WHERE id::text LIKE '60000000-0000-4000-8000-00000000000%'
+        OR idempotency_key LIKE 'verify:%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_artifacts
+      WHERE id::text LIKE '80000000-0000-4000-8000-00000000000%'
+        OR series_id::text LIKE 'a0000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_assets
+      WHERE id::text LIKE '90000000-0000-4000-8000-00000000000%'
+        OR storage_path LIKE 'verification/%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_publications
+      WHERE id::text LIKE 'b0000000-0000-4000-8000-00000000000%'
+        OR content_hash LIKE 'verify:%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.organization_ai_usage
+      WHERE reference_id LIKE 'verify:%'
+    ) THEN
+    RAISE EXCEPTION 'Rollback-only verifier left helpers or fixtures behind';
+  END IF;
+END;
+$verify_rollback$;
+ROLLBACK;
+
+\echo '0035 rollback-only DML verification passed.'

--- a/docs/superpowers/plans/2026-07-12-pr-13-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-12-pr-13-review-fixes.md
@@ -4,7 +4,7 @@
 
 **Goal:** Close the three unresolved PR #13 review findings by making content jobs server-write-only, preserving and authorizing lesson organization ownership, and restoring deletion of non-approved lesson artifacts.
 
-**Architecture:** Put request-shape and organization-transfer decisions in a small, side-effect-free lesson-update module, while the lesson route remains the I/O coordinator. Keep the final lesson mutation on the authenticated Supabase client and use a service-role client only to read membership evidence. Add a forward-only `0035` migration as the atomic database boundary for job privileges, organization reassignment, and artifact immutability, plus a transactional SQL acceptance script for environments where the migration is applied.
+**Architecture:** Put request-shape and organization-transfer decisions in a small, side-effect-free lesson-update module, while the lesson route remains the I/O coordinator. Keep the final lesson mutation on the authenticated Supabase client and use a service-role client only to read membership evidence. Add a forward-only `0035` migration as the atomic database boundary for job privileges, organization reassignment, and artifact immutability, plus split prerequisite, catalog, and rollback-only DML verification driven by a fail-closed PowerShell runner.
 
 **Tech Stack:** Next.js 16, TypeScript 5.9, Zod 3, Supabase/PostgreSQL RLS and trigger functions, Vitest 4, pnpm 10, PowerShell/psql rollout commands.
 
@@ -17,14 +17,16 @@
 - Omitted `organizationId` preserves ownership; explicit `null` and malformed UUIDs are rejected; edit mode must omit the property entirely.
 - A real teacher reassignment requires active `owner` or `admin` membership in the current organization, when present, and the target organization. A global admin is exempt from membership checks.
 - The route may use `createServerSupabase()` only for trusted membership reads. The final lesson update must use `createSSRUserSupabase()` so the database trigger sees the authenticated actor.
+- Authenticated lesson updates have no table-level `UPDATE` grant. Their exact column allowlist is `title`, `subject`, `gradelevel`, `objectives`, `content`, `organization_id`, and `updated_at`; authenticated global admins receive no protected-column exception.
 - Existing job reservations remain attributed to their original organization. No backfill or transfer of queued/running jobs is in scope.
 - Source-contract tests supplement behavioral tests; they are not the sole proof of route or database behavior.
 - Apply each production change only after its focused regression test fails for the expected reason.
+- Both isolated PostgreSQL runner modes (`canonical` and `upgrade`) are mandatory pre-merge gates. Missing database access is a blocked verification result, not permission to merge on source tests alone.
 
 ## Planning Discoveries and Scope Boundaries
 
-- The raw historical migration chain is not replayable: `0021_add_teacherid_to_lessons_assessments.sql` creates `teacher_id` but indexes nonexistent `teacherid` columns. This task must not rewrite that applied file. A clean-environment gate therefore starts from an operator-provided canonical schema baseline at `0034`, then applies `0035`. Repairing historical replay or checking in a new baseline is a separate migration-governance decision.
-- `enable_rls_migration.sql` contains legacy `lessons.teacher`/`admins` update policies. Migration `0035` must replace those lesson manager policies with `can_manage_lesson(id)` policies so normalized teacher/admin updates can reach the new organization trigger.
+- The raw historical migration chain is not replayable: `0021_add_teacherid_to_lessons_assessments.sql` creates `teacher_id` but indexes nonexistent `teacherid` columns. This task must not rewrite that applied file. Database gates therefore start from an operator-provided empty canonical schema baseline at `0034` and a separate representative upgrade-state clone at `0034`, then independently apply `0035`. Repairing historical replay or checking in a new baseline is a separate migration-governance decision.
+- `enable_rls_migration.sql` contains legacy `lessons.teacher`/`admins` manager policies and broad authenticated updates. Migration `0035` must replace those policies with normalized manager policies and replace table-level lesson `UPDATE` with explicit editable-column grants.
 - `claim_content_jobs` claims globally, not by fixture ID. Full DML verification is allowed only on an isolated disposable database with no pre-existing queued/running jobs. Shared staging and production may run catalog-only verification, never the claim/DML matrix.
 
 ---
@@ -39,6 +41,7 @@
 - Produces: `updateLessonSchema` and `LessonUpdateInput`.
 - Produces: `mapLessonUpdate(input, updatedAt)` with conditional `organization_id` ownership.
 - Produces: `requiredOrganizationAdminIds(input)` and `hasRequiredOrganizationAdminMemberships(requiredIds, memberships)`.
+- Produces: `isLessonOrganizationGuardError(error, organizationChangeRequested)` for narrow database-error classification.
 - Consumes: the existing API fields `title`, `subject`, `gradeLevel`, `objectives`, `content`, and optional non-null `organizationId`.
 
 - [ ] **Step 1: Write the failing schema and mapper tests**
@@ -81,6 +84,23 @@ Test these states before implementation:
 | Inactive, `member`, or missing row | unchanged required IDs | rejected |
 
 Use role strings from `DBOrganizationMember` and include owner-success, admin-success, mixed-role success, missing-source, missing-target, inactive, and ordinary-member cases.
+
+Add error-classification cases:
+
+```ts
+expect(isLessonOrganizationGuardError(
+  { code: '42501', message: 'Active owner or admin membership in target organization is required' },
+  true,
+)).toBe(true);
+expect(isLessonOrganizationGuardError(
+  { code: '42501', message: 'permission denied for table lessons' },
+  true,
+)).toBe(false);
+expect(isLessonOrganizationGuardError(
+  { code: '42501', message: 'Active owner or admin membership in target organization is required' },
+  false,
+)).toBe(false);
+```
 
 - [ ] **Step 3: Verify the new test fails**
 
@@ -164,6 +184,24 @@ export function hasRequiredOrganizationAdminMemberships(
     && membership.is_active
     && (membership.role === 'owner' || membership.role === 'admin')
   )));
+}
+
+const LESSON_ORGANIZATION_GUARD_MESSAGES = new Set([
+  'Not authorized to reassign lesson organization',
+  'Lesson organization cannot be cleared',
+  'Active owner or admin membership in current organization is required',
+  'Active owner or admin membership in target organization is required',
+]);
+
+export function isLessonOrganizationGuardError(
+  error: unknown,
+  organizationChangeRequested: boolean,
+): boolean {
+  if (!organizationChangeRequested || typeof error !== 'object' || error === null) return false;
+  const candidate = error as { code?: unknown; message?: unknown };
+  return candidate.code === '42501'
+    && typeof candidate.message === 'string'
+    && LESSON_ORGANIZATION_GUARD_MESSAGES.has(candidate.message);
 }
 ```
 
@@ -252,7 +290,9 @@ Add focused tests for:
 6. global admin: membership query is bypassed and update succeeds;
 7. membership query error: `500`, update never called;
 8. explicit `null` or malformed UUID: `400`, update never called;
-9. database guard returns SQLSTATE `42501`: route returns `403` rather than exposing it as `500`.
+9. a real organization change returning SQLSTATE `42501` plus a known guard message: route returns `403`;
+10. a non-transfer `42501`: route returns generic `500` rather than an organization denial;
+11. a real organization change with an unknown `42501` message: route returns generic `500`.
 
 - [ ] **Step 3: Update the supplemental source contract to fail on unsafe wiring**
 
@@ -261,6 +301,7 @@ Replace the assertion that currently requires inline `organization_id: body.orga
 ```ts
 expect(route).not.toContain('organization_id: body.organizationId ?? null');
 expect(route).toContain('mapLessonUpdate(');
+expect(route).toContain('isLessonOrganizationGuardError(');
 expect(route).toContain('createServerSupabase');
 expect(route).toContain('createSSRUserSupabase');
 expect(route).toContain(".select('id, teacher_id, organization_id')");
@@ -299,8 +340,9 @@ const { data: memberships, error: membershipError } = await trustedSupabase
 
 7. return `403` before mutation if any required ID lacks an active owner/admin row;
 8. call `userSupabase.from('lessons').update(mapLessonUpdate(body, new Date().toISOString()))`;
-9. map a returned database error with code `42501` to `403` because it represents the atomic guard rejecting a raced or direct unauthorized transfer;
-10. return a Zod-specific `400` response in the catch block and retain the existing generic database failure behavior otherwise. Use stable client-facing errors: `Not authorized to reassign this lesson organization` for transfer `403`, `Invalid lesson update` for `400`, and the existing generic `Failed to update lesson` for unexpected `500`.
+9. compute `organizationChangeRequested` independently of membership lookup as `Object.hasOwn(body, 'organizationId') && body.organizationId !== existing.organization_id`;
+10. map a returned database error to the transfer-specific `403` only when `isLessonOrganizationGuardError(error, organizationChangeRequested)` is true; throw every other database error into the existing generic `500` path;
+11. return a Zod-specific `400` response in the catch block and retain the existing generic database failure behavior otherwise. Use stable client-facing errors: `Not authorized to reassign this lesson organization` for known transfer rejections, `Invalid lesson update` for `400`, and the existing generic `Failed to update lesson` for unexpected `500`.
 
 - [ ] **Step 6: Verify Task 2**
 
@@ -447,7 +489,7 @@ git commit -m "fix(lessons): preserve edit ownership"
 
 **Interfaces:**
 - Changes: `content_jobs` policies and table privileges.
-- Replaces: legacy lesson manager RLS policies with normalized manager policies and a NEW-row owner check.
+- Replaces: legacy lesson manager RLS policies with normalized manager policies, a NEW-row owner check, and an authenticated editable-column allowlist.
 - Reasserts: service-role-only execution for the three content-job-mutating RPCs.
 - Replaces: `public.prevent_approved_artifact_mutation()` and `lesson_artifacts_approved_immutable`.
 - Produces: `public.prevent_invalid_lesson_organization_reassignment()` and `lessons_organization_reassignment_guard`.
@@ -464,10 +506,14 @@ Read both `0033_objective_artifacts.sql` and `0035_harden_lesson_artifact_writes
   - `claim_content_jobs(text, integer, integer)`;
   - `enqueue_content_jobs_with_usage(uuid, uuid, jsonb, jsonb)`;
   - `create_uploaded_lesson_artifact(uuid, uuid, text, jsonb, jsonb, jsonb)`;
-- enable RLS on `public.lessons`, drop legacy `lessons_teacher_own` and `lessons_admin_all`, then idempotently create `lessons_manager_select`, `lessons_manager_update`, and `lessons_manager_delete`; update `USING` checks old-row management and `WITH CHECK` validates the NEW `teacher_id` through `can_assign_lesson_teacher(teacher_id)`;
+- wrap the complete migration in `BEGIN;` and `COMMIT;` so a failing statement cannot leave partial ACL/RLS hardening;
+- enable RLS on `public.lessons`, dynamically drop every existing `INSERT`, `UPDATE`, `DELETE`, or `ALL` policy that applies to `PUBLIC`, `anon`, or `authenticated`, drop and recreate the normalized manager policies, and leave exactly `lessons_manager_update` plus `lessons_manager_delete` as authenticated write policies; update `USING` checks old-row management and `WITH CHECK` validates the NEW `teacher_id` through `can_assign_lesson_teacher(teacher_id)`;
+- revoke broad lesson UPDATE privileges from `PUBLIC`, `anon`, and `authenticated`, then grant authenticated UPDATE only on `title`, `subject`, `gradelevel`, `objectives`, `content`, `organization_id`, and `updated_at`; legacy `teacher`, normalized `teacher_id`, and `current_publication_id` must remain non-updatable to authenticated clients;
 - artifact trigger function branches on `TG_OP = 'DELETE'`, returning `OLD` for delete and `NEW` for update;
 - both affected triggers are dropped and recreated;
 - organization trigger is `BEFORE UPDATE OF organization_id` and contains service-role bypass, `can_manage_lesson(OLD.id)`, null rejection, global-admin bypass, active owner/admin source/target checks, and SQLSTATE `42501` on every rejection.
+
+Assert the source begins with `BEGIN;` and ends with `COMMIT;`; do not rely on a deployment tool to wrap the migration.
 
 - [ ] **Step 2: Verify the migration test fails**
 
@@ -494,10 +540,30 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.content_jobs TO service_rol
 
 For each exact job-mutating RPC signature, `REVOKE ALL ... FROM PUBLIC, anon, authenticated` and `GRANT EXECUTE ... TO service_role`. Do not alter quota calculations, idempotency behavior, or existing rows.
 
-In the same forward migration, enable RLS, add a hardened NEW-row owner predicate, and replace the legacy lesson manager policies without restoring direct lesson inserts:
+Start the migration with `BEGIN;`. In the same forward migration, enable RLS, add a hardened NEW-row owner predicate, and replace all browser-applicable lesson write policies without restoring direct lesson inserts:
 
 ```sql
 ALTER TABLE public.lessons ENABLE ROW LEVEL SECURITY;
+
+DO $$
+DECLARE
+  policy_row record;
+BEGIN
+  FOR policy_row IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'lessons'
+      AND cmd IN ('ALL', 'INSERT', 'UPDATE', 'DELETE')
+      AND roles && ARRAY['public', 'anon', 'authenticated']::name[]
+  LOOP
+    EXECUTE format(
+      'DROP POLICY IF EXISTS %I ON public.lessons',
+      policy_row.policyname
+    );
+  END LOOP;
+END;
+$$;
 
 CREATE OR REPLACE FUNCTION public.can_assign_lesson_teacher(p_teacher_id uuid)
 RETURNS boolean
@@ -542,7 +608,48 @@ CREATE POLICY lessons_manager_delete ON public.lessons
   USING (public.can_manage_lesson(id));
 ```
 
-Keep the existing student and broad teacher read policies. Lesson creation remains service-role-only through `create_lesson_draft`; do not add an authenticated insert policy. The NEW-row predicate must have tests proving a teacher cannot change `teacher_id`, while a global admin can perform an intentional ownership change.
+Keep the existing student and broad teacher read policies. Lesson creation remains service-role-only through `create_lesson_draft`; do not add an authenticated insert policy. The NEW-row predicate remains defense in depth, while column-privilege tests prove neither a teacher nor an authenticated global admin can directly change `teacher_id`; intentional ownership maintenance is service-role-only.
+
+After the policy definitions, establish the column boundary explicitly:
+
+```sql
+REVOKE UPDATE ON TABLE public.lessons FROM PUBLIC, anon, authenticated;
+
+DO $$
+DECLARE
+  lesson_columns text;
+BEGIN
+  SELECT string_agg(quote_ident(attribute.attname), ', ' ORDER BY attribute.attnum)
+  INTO lesson_columns
+  FROM pg_attribute attribute
+  WHERE attribute.attrelid = 'public.lessons'::regclass
+    AND attribute.attnum > 0
+    AND NOT attribute.attisdropped;
+
+  IF lesson_columns IS NOT NULL THEN
+    EXECUTE format(
+      'REVOKE UPDATE (%s) ON TABLE public.lessons FROM PUBLIC, anon, authenticated',
+      lesson_columns
+    );
+  END IF;
+END;
+$$;
+
+GRANT UPDATE (
+  title,
+  subject,
+  gradelevel,
+  objectives,
+  content,
+  organization_id,
+  updated_at
+) ON public.lessons TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.lessons TO service_role;
+```
+
+Authenticated global admins follow the same editable-column allowlist. Intentional changes to `teacher`, `teacher_id`, or `current_publication_id` use a service-role maintenance path; do not restore broad authenticated UPDATE to support them.
+
+End the migration with `COMMIT;`. Any error before that boundary must roll back the complete migration.
 
 - [ ] **Step 4: Repair approved-artifact trigger returns**
 
@@ -649,85 +756,296 @@ git diff --check
 
 Expected: tests and lint pass; migration status lists only `?? supabase/migrations/0035_harden_lesson_artifact_writes.sql`; whitespace check passes.
 
-- [ ] **Step 7: Commit Task 4**
+- [ ] **Step 7: Leave Task 4 at a verified checkpoint**
 
 ```powershell
-git add supabase/migrations/0035_harden_lesson_artifact_writes.sql src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
-git commit -m "fix(db): harden lesson artifact writes"
+git status --short -- supabase/migrations/0035_harden_lesson_artifact_writes.sql src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
 ```
+
+Expected: both files remain uncommitted. Task 5 must apply the migration and pass the real PostgreSQL gate before either file is committed.
 
 ---
 
 ### Task 5: Add the transactional database acceptance gate
 
 **Files:**
-- Create: `supabase/verification/0035_harden_lesson_artifact_writes.sql`
+- Reference (already checked in with this plan): `docs/superpowers/plans/2026-07-12-pr-13-0035-dml-template.sql`
+- Create: `supabase/verification/0034_prerequisites.sql`
+- Create: `supabase/verification/0035_catalog.sql`
+- Create: `supabase/verification/0035_dml.sql`
+- Create: `scripts/verify-0035.ps1`
+- Create: `src/lib/lesson-artifacts/__tests__/database-verifier-contract.test.ts`
 - Modify: `src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts`
 
 **Interfaces:**
-- Consumes: `run_dml=false` for catalog-only checks on a migrated environment, or `run_dml=true` plus a direct migration-owner connection to an isolated disposable database that can `SET ROLE authenticated` and `SET ROLE service_role`.
-- Produces: a non-zero `psql` exit on any catalog, privilege, trigger, or DML invariant failure.
-- Leaves: no fixtures, because the script runs inside `BEGIN`/`ROLLBACK`.
+- Consumes: two distinct isolated databases still at migration `0034`: an empty schema-only canonical clone and a representative upgrade-state clone. Each URL is supplied only to `scripts/verify-0035.ps1` with an explicit `-Mode` and `-ConfirmDisposable`.
+- Produces: ordered prerequisite, migration, read-only catalog, and rollback-only DML checks with a non-zero exit on any failure.
+- Leaves: migration `0035` applied to each disposable clone but no fixtures or helper functions because `0035_dml.sql` ends in `ROLLBACK`; shared targets run only `0035_catalog.sql`.
 
-- [ ] **Step 1: Extend the migration test with a failing verifier contract**
+- [ ] **Step 1: Write the failing verifier-wiring test**
 
-Read the verification file and assert it contains:
+Create `src/lib/lesson-artifacts/__tests__/database-verifier-contract.test.ts` with this complete content:
 
-- `\set ON_ERROR_STOP on`, `BEGIN`, and final `ROLLBACK`;
-- a `run_dml` psql switch that always runs catalog checks and encloses fixtures/role switching/claim behavior in the DML-only branch;
-- `pg_policies`, `has_table_privilege`, `has_function_privilege`, and `pg_trigger` assertions;
-- `pg_class.relrowsecurity = true` for `public.lessons`, absence of `lessons_teacher_own`/`lessons_admin_all`, and presence of normalized manager select/update/delete policies with the NEW-row owner predicate;
-- checks for authenticated select plus denied insert/update/delete;
-- service enqueue, upload, cancel/retry, and worker-state transitions;
-- draft/rejected delete, draft update, approved update/delete rejection, and non-approved cascade;
-- null/source/target transfer rejection, owner/admin success, global-admin success, and service-role maintenance.
-- unchanged original job/usage organization and reservation count after lesson reassignment plus retry.
+```ts
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+const normalize = (value: string) => value.replace(/\r\n/g, '\n').trim();
+
+describe('0035 PostgreSQL verification wiring', () => {
+  it('runs the isolated database gates in fail-closed order', () => {
+    const runner = read('scripts/verify-0035.ps1');
+    const preflight = runner.indexOf("Invoke-CheckedPsql 'supabase/verification/0034_prerequisites.sql'");
+    const migration = runner.indexOf("Invoke-CheckedPsql 'supabase/migrations/0035_harden_lesson_artifact_writes.sql'");
+    const catalog = runner.indexOf("Invoke-CheckedPsql 'supabase/verification/0035_catalog.sql'");
+    const dml = runner.indexOf("Invoke-CheckedPsql 'supabase/verification/0035_dml.sql'");
+    expect(runner).toContain('[switch]$ConfirmDisposable');
+    expect(runner).toContain("[ValidateSet('canonical', 'upgrade')]");
+    expect(runner).toContain('require_empty=');
+    expect(runner).toContain("$ErrorActionPreference = 'Stop'");
+    expect(runner).toContain('if ($LASTEXITCODE -ne 0)');
+    expect(preflight).toBeGreaterThan(-1);
+    expect(migration).toBeGreaterThan(preflight);
+    expect(catalog).toBeGreaterThan(migration);
+    expect(dml).toBeGreaterThan(catalog);
+    expect(runner).not.toContain('SHARED_DATABASE_URL');
+    expect(runner).not.toContain('$env:DATABASE_URL');
+  });
+
+  it('keeps shared verification read-only and isolated DML rollback-only', () => {
+    const prerequisites = read('supabase/verification/0034_prerequisites.sql').toLowerCase();
+    const catalog = read('supabase/verification/0035_catalog.sql').toLowerCase();
+    const dmlSource = read('supabase/verification/0035_dml.sql');
+    const dml = dmlSource.toLowerCase();
+    const dmlTemplate = read(
+      'docs/superpowers/plans/2026-07-12-pr-13-0035-dml-template.sql',
+    );
+    expect(prerequisites).toContain('begin read only');
+    expect(prerequisites).toContain('require_empty must be true or false');
+    expect(prerequisites).toContain('require_empty_valid');
+    expect(prerequisites).toContain('verification fixture namespace is not clean');
+    expect(catalog).toContain('begin read only');
+    expect(catalog).toContain('has_column_privilege');
+    expect(dml).toContain('begin;');
+    expect(dml).toContain('set local role authenticated');
+    expect(dml).toContain('set local role service_role');
+    expect(dml).toContain('_verify_0035_expect_error');
+    expect(dml.trimEnd()).toMatch(/rollback;\s*\\echo '0035 rollback-only dml verification passed\.'$/);
+    expect(normalize(dmlSource)).toBe(normalize(dmlTemplate));
+  });
+});
+```
 
 - [ ] **Step 2: Verify the extended test fails**
 
 Run:
 
 ```powershell
-pnpm exec vitest run src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts src/lib/lesson-artifacts/__tests__/database-verifier-contract.test.ts
 ```
 
-Expected: FAIL because the verification script does not exist.
+Expected: FAIL with `ENOENT` because the verifier files and runner do not exist.
 
-- [ ] **Step 3: Implement a self-contained, rollback-only SQL verifier**
+- [ ] **Step 3: Implement the split, fail-closed database verifier**
 
-The script must:
-
-1. enable `ON_ERROR_STOP`, default `run_dml` to false when omitted, and start a transaction;
-2. always verify the effective policy/privilege/trigger catalog matrix, including normalized lesson manager policies;
-3. when `run_dml=true`, preflight that the connection can assume both roles and that no queued/running content jobs pre-exist;
-4. only inside that DML branch, create deterministic fixtures and run role-switched behavior tests;
-5. use self-asserting `DO` blocks that raise on false catalog predicates, wrong row counts, wrong persisted values, or unexpected SQLSTATEs;
-6. set local JWT claims/roles exactly when exercising authenticated and service-role behavior;
-7. verify all three mutating RPC ACLs and the existing service-only `insert_generated_lesson_artifact(uuid, uuid, integer, text, integer, jsonb, jsonb, jsonb, uuid, uuid, uuid)` worker RPC;
-8. exercise the DML and trigger matrix listed in Step 1;
-9. close the conditional and roll back after successful verification.
-
-Use this psql framing:
+Create `0034_prerequisites.sql` as a read-only gate. The runner must supply `require_empty=true` for the canonical clone and `require_empty=false` for the upgrade clone; omission is an error, not a default. Both modes require a direct migration-owner connection, the normalized canonical `0034` function/policy baseline, absence of `0035`, no globally claimable jobs, and a clean deterministic fixture namespace. Canonical mode additionally requires an empty schema-only database.
 
 ```sql
 \set ON_ERROR_STOP on
-\if :{?run_dml}
+\if :{?require_empty}
 \else
-  \set run_dml false
+  \echo 'require_empty must be true or false'
+  \quit 3
 \endif
 
-BEGIN;
-\if :run_dml
+SELECT :'require_empty' IN ('true', 'false') AS require_empty_valid
+\gset
+\if :require_empty_valid
+\else
+  \echo 'require_empty must be true or false'
+  \quit 3
 \endif
+
+BEGIN READ ONLY;
+
+DO $verify_0034$
+DECLARE
+  manage_definition text;
+BEGIN
+  IF NOT pg_has_role(current_user, 'authenticated', 'MEMBER')
+    OR NOT pg_has_role(current_user, 'service_role', 'MEMBER') THEN
+    RAISE EXCEPTION 'Verification connection must be able to SET ROLE authenticated and service_role';
+  END IF;
+
+  IF to_regprocedure('public.can_manage_lesson(uuid)') IS NULL
+    OR to_regprocedure('public.claim_content_jobs(text,integer,integer)') IS NULL
+    OR to_regprocedure('public.enqueue_content_jobs_with_usage(uuid,uuid,jsonb,jsonb)') IS NULL
+    OR to_regprocedure('public.create_uploaded_lesson_artifact(uuid,uuid,text,jsonb,jsonb,jsonb)') IS NULL
+    OR to_regprocedure('public.prevent_approved_artifact_mutation()') IS NULL THEN
+    RAISE EXCEPTION 'Canonical 0034 prerequisite functions are missing';
+  END IF;
+
+  SELECT lower(pg_get_functiondef('public.can_manage_lesson(uuid)'::regprocedure))
+  INTO manage_definition;
+  IF position('l.teacher_id' IN manage_definition) = 0
+    OR position('t.user_id = auth.uid()' IN manage_definition) = 0 THEN
+    RAISE EXCEPTION 'can_manage_lesson does not match the normalized 0034 ownership baseline';
+  END IF;
+
+  IF to_regprocedure('public.can_assign_lesson_teacher(uuid)') IS NOT NULL
+    OR to_regprocedure('public.prevent_invalid_lesson_organization_reassignment()') IS NOT NULL
+    OR EXISTS (
+      SELECT 1 FROM pg_trigger
+      WHERE tgrelid = 'public.lessons'::regclass
+        AND tgname = 'lessons_organization_reassignment_guard'
+        AND NOT tgisinternal
+    ) THEN
+    RAISE EXCEPTION 'Disposable database is already beyond migration 0034';
+  END IF;
+
+  IF (
+    SELECT count(*) FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'content_jobs'
+      AND policyname IN (
+        'content_jobs_select_own',
+        'content_jobs_insert_own',
+        'content_jobs_update_own'
+      )
+  ) <> 3 THEN
+    RAISE EXCEPTION '0034 content_jobs policy baseline is incomplete';
+  END IF;
+END;
+$verify_0034$;
+
+DO $verify_isolation$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.content_jobs WHERE status IN ('queued', 'running')
+  ) THEN
+    RAISE EXCEPTION 'Isolated verification clone contains globally claimable jobs';
+  END IF;
+
+  IF EXISTS (
+      SELECT 1 FROM public.users
+      WHERE id::text LIKE '10000000-0000-4000-8000-00000000000%'
+        OR email LIKE 'verify-%@example.invalid'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.teachers
+      WHERE id::text LIKE '20000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.organizations
+      WHERE id::text LIKE '30000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lessons
+      WHERE id = '40000000-0000-4000-8000-000000000001'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_objectives
+      WHERE id::text LIKE '50000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_publications
+      WHERE id::text LIKE 'b0000000-0000-4000-8000-00000000000%'
+        OR content_hash LIKE 'verify:%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.content_jobs
+      WHERE id::text LIKE '60000000-0000-4000-8000-00000000000%'
+        OR idempotency_key LIKE 'verify:%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_artifacts
+      WHERE id::text LIKE '80000000-0000-4000-8000-00000000000%'
+        OR series_id::text LIKE 'a0000000-0000-4000-8000-00000000000%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.lesson_assets
+      WHERE id = '90000000-0000-4000-8000-000000000001'
+        OR storage_path LIKE 'verification/%'
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.organization_ai_usage
+      WHERE reference_id LIKE 'verify:%'
+    ) THEN
+    RAISE EXCEPTION 'Verification fixture namespace is not clean';
+  END IF;
+END;
+$verify_isolation$;
+
+\if :require_empty
+DO $verify_canonical_empty$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.users)
+    OR EXISTS (SELECT 1 FROM public.organizations)
+    OR EXISTS (SELECT 1 FROM public.lessons)
+    OR EXISTS (SELECT 1 FROM public.content_jobs) THEN
+    RAISE EXCEPTION 'Canonical verification requires an empty schema-only 0034 baseline';
+  END IF;
+END;
+$verify_canonical_empty$;
+\endif
+
 ROLLBACK;
 ```
 
-Place this runnable catalog block immediately after `BEGIN` and before the DML conditional:
+Create `scripts/verify-0035.ps1` with this exact orchestration. The confirmation switch is a deliberate operator assertion that the URL is isolated and disposable; the script itself never reads a shared-database environment variable.
+
+```powershell
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$DisposableDatabaseUrl,
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('canonical', 'upgrade')]
+  [string]$Mode,
+  [Parameter(Mandatory = $true)]
+  [switch]$ConfirmDisposable
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not $ConfirmDisposable) {
+  throw 'Pass -ConfirmDisposable only for an isolated database still at migration 0034.'
+}
+if ([string]::IsNullOrWhiteSpace($DisposableDatabaseUrl)) {
+  throw 'DisposableDatabaseUrl is required.'
+}
+
+$psql = Get-Command psql -ErrorAction Stop
+$root = Split-Path -Parent $PSScriptRoot
+$requireEmpty = if ($Mode -eq 'canonical') { 'true' } else { 'false' }
+
+function Invoke-CheckedPsql([string]$RelativePath, [string[]]$Variables = @()) {
+  $path = Join-Path $root $RelativePath
+  $arguments = @($DisposableDatabaseUrl, '-X', '--set', 'ON_ERROR_STOP=1')
+  foreach ($variable in $Variables) {
+    $arguments += @('--set', $variable)
+  }
+  $arguments += @('--file', $path)
+  & $psql.Source @arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "psql failed for $RelativePath with exit code $LASTEXITCODE"
+  }
+}
+
+Invoke-CheckedPsql 'supabase/verification/0034_prerequisites.sql' @("require_empty=$requireEmpty")
+Invoke-CheckedPsql 'supabase/migrations/0035_harden_lesson_artifact_writes.sql'
+Invoke-CheckedPsql 'supabase/verification/0035_catalog.sql'
+Invoke-CheckedPsql 'supabase/verification/0035_dml.sql'
+Write-Host "0035 isolated PostgreSQL verification passed ($Mode)."
+```
+
+Create `0035_catalog.sql` with `\set ON_ERROR_STOP on`, `BEGIN READ ONLY;`, the following self-asserting catalog block, and `ROLLBACK;`. This file is the only verifier permitted on a shared target.
 
 ```sql
 DO $verify_catalog$
 DECLARE
   function_name text;
+  artifact_definition text;
   job_functions constant text[] := ARRAY[
     'public.claim_content_jobs(text,integer,integer)',
     'public.enqueue_content_jobs_with_usage(uuid,uuid,jsonb,jsonb)',
@@ -772,6 +1090,10 @@ BEGIN
     'authenticated',
     'public.insert_generated_lesson_artifact(uuid,uuid,integer,text,integer,jsonb,jsonb,jsonb,uuid,uuid,uuid)',
     'EXECUTE'
+  ) OR has_function_privilege(
+    'anon',
+    'public.insert_generated_lesson_artifact(uuid,uuid,integer,text,integer,jsonb,jsonb,jsonb,uuid,uuid,uuid)',
+    'EXECUTE'
   ) OR NOT has_function_privilege(
     'service_role',
     'public.insert_generated_lesson_artifact(uuid,uuid,integer,text,integer,jsonb,jsonb,jsonb,uuid,uuid,uuid)',
@@ -791,17 +1113,89 @@ BEGIN
     SELECT count(*) FROM pg_policies
     WHERE schemaname = 'public' AND tablename = 'lessons'
       AND policyname IN ('lessons_manager_select', 'lessons_manager_update', 'lessons_manager_delete')
-  ) <> 3 OR NOT EXISTS (
+  ) <> 3 OR EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'lessons'
+      AND cmd IN ('ALL', 'INSERT', 'UPDATE', 'DELETE')
+      AND roles && ARRAY['public', 'anon', 'authenticated']::name[]
+      AND NOT (
+        policyname = 'lessons_manager_update'
+        AND cmd = 'UPDATE'
+        AND roles = ARRAY['authenticated']::name[]
+        OR policyname = 'lessons_manager_delete'
+        AND cmd = 'DELETE'
+        AND roles = ARRAY['authenticated']::name[]
+      )
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'lessons'
+      AND policyname = 'lessons_manager_select'
+      AND cmd = 'SELECT'
+      AND roles = ARRAY['authenticated']::name[]
+      AND qual LIKE '%can_manage_lesson%'
+      AND with_check IS NULL
+  ) OR NOT EXISTS (
     SELECT 1 FROM pg_policies
     WHERE schemaname = 'public' AND tablename = 'lessons'
       AND policyname = 'lessons_manager_update'
+      AND cmd = 'UPDATE'
+      AND roles = ARRAY['authenticated']::name[]
       AND qual LIKE '%can_manage_lesson%'
       AND with_check LIKE '%can_assign_lesson_teacher%'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'lessons'
+      AND policyname = 'lessons_manager_delete'
+      AND cmd = 'DELETE'
+      AND roles = ARRAY['authenticated']::name[]
+      AND qual LIKE '%can_manage_lesson%'
+      AND with_check IS NULL
   ) OR to_regprocedure('public.can_assign_lesson_teacher(uuid)') IS NULL
     OR NOT has_function_privilege(
       'authenticated', 'public.can_assign_lesson_teacher(uuid)', 'EXECUTE'
+    ) OR has_function_privilege(
+      'anon', 'public.can_assign_lesson_teacher(uuid)', 'EXECUTE'
+    ) OR NOT has_function_privilege(
+      'service_role', 'public.can_assign_lesson_teacher(uuid)', 'EXECUTE'
     ) THEN
     RAISE EXCEPTION 'lesson manager RLS matrix is incorrect';
+  END IF;
+
+  IF has_table_privilege('authenticated', 'public.lessons', 'UPDATE')
+    OR has_any_column_privilege('anon', 'public.lessons', 'UPDATE')
+    OR NOT has_table_privilege('service_role', 'public.lessons', 'UPDATE')
+    OR EXISTS (
+      SELECT 1
+      FROM unnest(ARRAY[
+        'title', 'subject', 'gradelevel', 'objectives',
+        'content', 'organization_id', 'updated_at'
+      ]) AS allowed(column_name)
+      WHERE NOT has_column_privilege(
+        'authenticated',
+        'public.lessons',
+        allowed.column_name,
+        'UPDATE'
+      )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM pg_attribute attribute
+      WHERE attribute.attrelid = 'public.lessons'::regclass
+        AND attribute.attnum > 0
+        AND NOT attribute.attisdropped
+        AND NOT attribute.attname = ANY (ARRAY[
+          'title', 'subject', 'gradelevel', 'objectives',
+          'content', 'organization_id', 'updated_at'
+        ])
+        AND has_column_privilege(
+          'authenticated',
+          'public.lessons',
+          attribute.attname,
+          'UPDATE'
+        )
+    ) THEN
+    RAISE EXCEPTION 'lesson UPDATE column privilege matrix is incorrect';
   END IF;
 
   IF NOT EXISTS (
@@ -819,11 +1213,24 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'hardening trigger attachment is incorrect';
   END IF;
+
+  SELECT lower(pg_get_functiondef(
+    'public.prevent_approved_artifact_mutation()'::regprocedure
+  )) INTO artifact_definition;
+  IF position('if tg_op = ''delete'' then' IN artifact_definition) = 0
+    OR position('return old' IN artifact_definition) = 0
+    OR position('return new' IN artifact_definition) = 0 THEN
+    RAISE EXCEPTION 'approved-artifact trigger function definition is incorrect';
+  END IF;
 END;
 $verify_catalog$;
 ```
 
-The DML preflight must fail before fixtures if this query returns any row:
+Create `0035_dml.sql` by copying `docs/superpowers/plans/2026-07-12-pr-13-0035-dml-template.sql` exactly. The checked-in template is the authoritative executable body; the matrix and snippets below explain its acceptance intent and are not permission to replace it with a skeletal source-marker script. It starts with `\set ON_ERROR_STOP on` and `BEGIN;`, uses deterministic helper functions, fixtures and assertions, rolls the DML transaction back, verifies that rollback in a separate read-only transaction, and ends exactly with `\echo '0035 rollback-only DML verification passed.'`. Every actor block sets both scalar and JSON Supabase JWT claims before switching roles.
+
+Create rollback-scoped `public._verify_0035_assert(boolean,text)`, `public._verify_0035_expect_error(text,text,text)`, `public._verify_0035_assert_row_count(text,bigint,text)`, and `public._verify_0035_set_actor(uuid,text)` helpers as invoker-security PL/pgSQL functions with `SET search_path = pg_catalog, public`. Revoke `PUBLIC` execution from all four; grant only the three assertion helpers to `authenticated` and `service_role`, while `set_actor` remains executable only by the migration owner before each role switch. `expect_error` must execute its SQL, compare both `RETURNED_SQLSTATE` and `MESSAGE_TEXT`, and fail if the statement succeeds or raises a different error. `assert_row_count` must use `GET DIAGNOSTICS ... ROW_COUNT` and compare the exact affected count. `set_actor` must set both scalar claim GUCs and the JSON claims object. Because the enclosing transaction rolls back, these public helper definitions never persist.
+
+The DML preflight must run before fixtures and repeat the upgrade-safe isolation checks from `0034_prerequisites.sql`: the connection can assume `authenticated` and `service_role`, no queued/running job exists, and no row collides with the reserved verification IDs, `verify-%@example.invalid` emails, `verify:%` idempotency/reference/content-hash keys, `a0000000-...` artifact series IDs, or `verification/%` storage paths. Implement these as `DO` assertions, not visual/manual checks. In particular, this query must return no row:
 
 ```sql
 SELECT id FROM public.content_jobs
@@ -831,171 +1238,60 @@ WHERE status IN ('queued', 'running')
 LIMIT 1;
 ```
 
-Implement that as a `DO` assertion, not a visual/manual check.
-
-Use stable fixture variables so every assertion identifies the same rows:
-
-```sql
-\set teacher_user_id  '10000000-0000-4000-8000-000000000001'
-\set admin_user_id    '10000000-0000-4000-8000-000000000002'
-\set other_teacher_user_id '10000000-0000-4000-8000-000000000003'
-\set teacher_id       '20000000-0000-4000-8000-000000000001'
-\set other_teacher_id '20000000-0000-4000-8000-000000000002'
-\set source_org_id    '30000000-0000-4000-8000-000000000001'
-\set target_org_id    '30000000-0000-4000-8000-000000000002'
-\set lesson_id        '40000000-0000-4000-8000-000000000001'
-\set objective_id     '50000000-0000-4000-8000-000000000001'
-\set job_id           '60000000-0000-4000-8000-000000000001'
-\set upload_job_id    '60000000-0000-4000-8000-000000000002'
-\set batch_id         '70000000-0000-4000-8000-000000000001'
-\set upload_batch_id  '70000000-0000-4000-8000-000000000002'
-\set draft_artifact   '80000000-0000-4000-8000-000000000001'
-\set rejected_artifact '80000000-0000-4000-8000-000000000002'
-\set approved_artifact '80000000-0000-4000-8000-000000000003'
-\set upload_artifact  '80000000-0000-4000-8000-000000000004'
-\set upload_asset     '90000000-0000-4000-8000-000000000001'
-```
+The authoritative template uses literal reserved UUIDs and `verify:` namespaces rather than psql fixture variables. Do not add a second indirection layer: the prerequisite and DML preflights validate those literal namespaces before any insert.
 
 Insert only current-schema columns, using these exact fixture shapes:
 
 - `public.users(id, email, name, role)`: the owning teacher, a second teacher, and one global admin;
-- `public.teachers(id, user_id)`: both teacher profiles;
+- `public.teachers(id, user_id, subjects, grades)`: both teacher profiles with empty array fields;
 - `public.organizations(id, name, owner_id)`: source and target organizations;
 - `public.organization_members(organization_id, user_id, role, is_active)`: normalize the trigger-created teacher rows to the role/state needed by each test, restoring active owner/admin rows between rejection cases;
-- `public.lessons(id, title, subject, gradelevel, objectives, content, teacher_id, organization_id)`: one teacher-owned source-organization lesson;
-- `public.lesson_objectives(id, lesson_id, text, position, revision)`: the active objective;
-- `public.lesson_artifacts(id, lesson_id, objective_id, series_id, version, objective_revision, kind, status, position, payload, source, created_by)`: separate draft, rejected, approved, and cascade fixtures with unique series IDs.
+- `public.lessons(id, title, subject, gradelevel, objectives, content, teacher_id, organization_id)`: one primary teacher-owned source-organization lesson plus one artifact-free manager-delete fixture;
+- `public.lesson_objectives(id, lesson_id, text, position, revision)`: one primary objective and one cascade-only objective at distinct positions;
+- `public.lesson_publications(id, lesson_id, version, manifest, warnings, content_hash, published_by)`: one valid deterministic publication used for `current_publication_id` ACL and service-maintenance assertions;
+- `public.lesson_artifacts(id, lesson_id, objective_id, series_id, version, objective_revision, kind, status, position, payload, source, created_by)`: draft, rejected, and approved fixtures under the primary objective, plus a single non-approved artifact under the cascade-only objective, all with unique series IDs.
+
+After organization setup, explicitly make the owning teacher an active source `owner` and target `admin`; this proves the first successful teacher transfer uses source ownership plus target administration. Before the global-admin bypass case, remove that admin user's organization memberships so the success cannot be attributed to membership. Before deleting the rejected artifact, update it and assert both exact row count one and persisted payload. Worker-completion updates must predicate on the expected `lease_owner` value and `lease_expires_at > now()` before clearing the lease. Exercise source and target membership failures separately for missing, inactive, and ordinary `member` rows, restoring the success state between groups.
+
+Use the real `publication_id` fixture when testing `current_publication_id`: authenticated teacher and global-admin attempts must fail with `42501` before any FK mutation, while service-role maintenance must set the pointer successfully and persist it. Perform any service-role `teacher_id` maintenance after teacher-authorization cases, or restore the original teacher before continuing.
 
 Use `ON CONFLICT` only where setup triggers can legitimately precreate a membership. Any unexpected pre-existing deterministic ID should fail the disposable-environment gate rather than silently reuse unrelated data.
 
-After inserting fixtures, expose those IDs to dollar-quoted assertion blocks:
+The template calls `_verify_0035_set_actor` as the migration owner before every role switch. That helper sets both scalar claim GUCs and the JSON claims object; authenticated and service roles cannot execute it themselves. Assertions use literal reserved IDs, so no temp-table privilege bridge is required.
 
-```sql
-CREATE TEMP TABLE verification_ids (
-  teacher_user_id uuid,
-  admin_user_id uuid,
-  other_teacher_user_id uuid,
-  teacher_id uuid,
-  other_teacher_id uuid,
-  source_org_id uuid,
-  target_org_id uuid,
-  lesson_id uuid,
-  objective_id uuid,
-  job_id uuid,
-  draft_artifact uuid,
-  rejected_artifact uuid,
-  approved_artifact uuid
-) ON COMMIT DROP;
-
-INSERT INTO verification_ids VALUES (
-  :'teacher_user_id', :'admin_user_id', :'other_teacher_user_id',
-  :'teacher_id', :'other_teacher_id',
-  :'source_org_id', :'target_org_id', :'lesson_id', :'objective_id', :'job_id',
-  :'draft_artifact', :'rejected_artifact', :'approved_artifact'
-);
-
-GRANT SELECT ON verification_ids TO authenticated, service_role;
-```
-
-Preflight the connection before inserts:
-
-```sql
-DO $$
-BEGIN
-  IF NOT pg_has_role(current_user, 'authenticated', 'MEMBER')
-    OR NOT pg_has_role(current_user, 'service_role', 'MEMBER') THEN
-    RAISE EXCEPTION 'Verification requires a direct migration-owner connection that can assume authenticated and service_role';
-  END IF;
-END;
-$$;
-SET LOCAL ROLE authenticated;
-RESET ROLE;
-SET LOCAL ROLE service_role;
-RESET ROLE;
-```
-
-For every authenticated block, set both scalar and JSON Supabase claim GUCs before assuming the role; repeat with `service_role` for trusted RPC blocks:
-
-```sql
-SELECT set_config('request.jwt.claim.sub', :'teacher_user_id', true);
-SELECT set_config('request.jwt.claim.role', 'authenticated', true);
-SELECT set_config(
-  'request.jwt.claims',
-  jsonb_build_object('sub', :'teacher_user_id', 'role', 'authenticated')::text,
-  true
-);
-SET LOCAL ROLE authenticated;
-SELECT id FROM public.content_jobs
-WHERE id = :'job_id' AND requested_by = :'teacher_user_id';
-RESET ROLE;
-```
-
-For service RPC blocks, replace the role in both claim GUCs and assume `service_role`:
-
-```sql
-SELECT set_config('request.jwt.claim.sub', :'teacher_user_id', true);
-SELECT set_config('request.jwt.claim.role', 'service_role', true);
-SELECT set_config(
-  'request.jwt.claims',
-  jsonb_build_object('sub', :'teacher_user_id', 'role', 'service_role')::text,
-  true
-);
-SET LOCAL ROLE service_role;
-SELECT auth.role();
-RESET ROLE;
-```
-
-Because psql does not substitute `:variables` inside dollar-quoted `DO` bodies, persist fixture IDs in a `pg_temp.verification_ids` row before exception blocks. PL/pgSQL blocks must select IDs from that temp row rather than embedding psql variables inside `$$ ... $$`. The explicit grant above is required because changing roles does not inherit the migration owner's temp-table privileges.
-
-Each expected failure belongs in a nested PL/pgSQL exception block. ACL and organization-guard failures must match SQLSTATE `42501` and the guard's stable message. Approved artifact update/delete must instead match SQLSTATE `P0001` and `Approved lesson artifacts are immutable; create a new version`. If the statement unexpectedly succeeds, or a different code/message is raised, re-raise and fail the script.
-
-Use the same fail-closed shape for every expected error:
-
-```sql
-DO $$
-DECLARE
-  ids pg_temp.verification_ids%ROWTYPE;
-  raised_message text;
-BEGIN
-  SELECT * INTO STRICT ids FROM pg_temp.verification_ids;
-  BEGIN
-    UPDATE public.lessons SET organization_id = NULL WHERE id = ids.lesson_id;
-    RAISE EXCEPTION 'Expected organization clear to fail' USING ERRCODE = 'ZX001';
-  EXCEPTION WHEN SQLSTATE '42501' THEN
-    GET STACKED DIAGNOSTICS raised_message = MESSAGE_TEXT;
-    IF raised_message <> 'Lesson organization cannot be cleared' THEN
-      RAISE EXCEPTION 'Wrong organization-clear error: %', raised_message;
-    END IF;
-  END;
-END;
-$$;
-```
+Every expected failure goes through `_verify_0035_expect_error`, which fails closed when the statement succeeds or the SQLSTATE differs. ACL failures require `42501`; organization-guard failures additionally require the exact stable guard message. Approved artifact update/delete requires `P0001` plus `Approved lesson artifacts are immutable; create a new version`.
 
 Implement this complete behavior matrix; do not replace a row with a source-string assertion:
 
 | Actor/setup | Operation | Required assertion |
 |---|---|---|
 | authenticated teacher, own job | `SELECT` | fixture job returned |
+| another authenticated teacher | `SELECT` the owner's job | zero rows returned |
 | authenticated teacher | direct job `INSERT`, `UPDATE`, `DELETE` | each raises `42501`; fixture unchanged |
 | service role | enqueue with usage | one queued job and one source-org usage row |
-| service role, isolated queue | `claim_content_jobs` | only fixture job becomes running with lease/attempt increment |
-| service role | cancel queued fixture | one row becomes cancelled |
-| service role | retry failed/cancelled fixture | one row returns to queued without new usage |
-| service role | worker success transition | one owned running row becomes succeeded and releases lease |
+| service role, isolated queue | claim quota job, then worker failure | only the quota job runs; owned unexpired lease transition makes it failed and releases the lease |
+| service role | enqueue separate no-usage lifecycle job, then cancel while queued | one row becomes cancelled and no usage row is added |
+| service role | retry, claim, and complete lifecycle job | it returns to queued, becomes running with lease/attempt increment, then succeeds through the owned unexpired lease |
+| service role, after a real lesson reassignment | retry, claim, and complete original quota job | succeeds without new usage or organization change |
 | service role | upload RPC | returned and persisted asset/artifact/job IDs match fixtures |
-| service role, draft/rejected | update/delete | exact row count one and persisted/absent state matches |
+| service role, draft/rejected | update/delete | each update affects one and persists; combined delete affects two and both rows are absent |
 | service role, approved | update/delete | `P0001` plus exact immutability message; row unchanged |
-| service role, non-approved parent | cascade delete | child artifact no longer exists |
+| service role, cascade-only objective | delete objective | its sole non-approved artifact disappears; primary draft/rejected/approved fixtures remain |
 | teacher active owner/admin in source and target | lesson reassignment | one row updated to target |
 | teacher missing/inactive/member in source | lesson reassignment | `42501` plus current-organization message; row unchanged |
 | teacher missing/inactive/member in target | lesson reassignment | `42501` plus target-organization message; row unchanged |
 | teacher | explicit organization `NULL` | `42501` plus clear message; row unchanged |
-| teacher | change `teacher_id` to another teacher | RLS rejects; owner remains unchanged |
+| authenticated teacher, manageable lesson | update allowlisted content fields | succeeds and persists |
+| authenticated teacher | direct lesson `INSERT` | raises `42501`; no row persists |
+| authenticated owner / non-owner | delete disposable managed lesson / delete another teacher's lesson | owner affects one row; non-owner affects zero |
+| authenticated teacher, another teacher's lesson | update an allowlisted field | row count is zero and row remains unchanged |
+| authenticated teacher | change normalized `teacher_id` or `current_publication_id` | each raises `42501`; protected values remain unchanged |
+| authenticated teacher, when legacy `teacher` exists | change legacy `teacher` | raises `42501`; value remains unchanged; skip only when catalog proves the column is absent |
 | global admin user | source-to-target reassignment | succeeds without memberships |
-| global admin user | intentional `teacher_id` change | succeeds through NEW-row owner predicate |
-| service role | reassignment or null maintenance | succeeds as explicit maintenance bypass |
+| authenticated global admin | change `teacher_id` or `current_publication_id`, plus legacy `teacher` when present | each raises `42501`; protected values remain unchanged |
+| service role | protected-field maintenance, organization reassignment, or null maintenance | succeeds through the explicit trusted bypass |
 
-Execute the DML rows in this order so each precondition is deterministic: isolation/role preflight; fixture inserts; service enqueue with usage; authenticated read/write denial; service claim; cancel/retry/worker transitions; upload RPC; artifact update/delete/cascade; teacher/admin/service organization cases; original-org quota assertions; `RESET ROLE`; `\endif`; `ROLLBACK`.
+Execute the authoritative template in this order so each precondition is deterministic: isolation/role preflight; fixture inserts; source-org quota enqueue; authenticated read/write denial; claim and fail the quota job through an owned unexpired lease; enqueue/cancel/retry/claim/complete a separate no-usage lifecycle job; artifact behavior; teacher/global-admin organization and column-ACL cases; a real service-role organization/protected-field reassignment; retry/claim/complete the original quota job; original-org job/usage assertions; upload RPC behavior; `RESET ROLE`; main `ROLLBACK`; read-only rollback proof; final `ROLLBACK`; success echo.
 
 Use exact catalog predicates such as:
 
@@ -1016,134 +1312,56 @@ IF NOT has_function_privilege(
 END IF;
 ```
 
-Authorization failures for ACL and organization-guard cases must assert SQLSTATE `42501`; any other error fails the verifier. For successful artifact behavior, capture `ROW_COUNT` and query persisted state: draft/rejected deletes each affect one row and leave no row, draft update affects one row and persists its new payload, and the non-approved parent cascade removes its child artifact. This prevents an unrelated FK/RLS error from satisfying the test.
+Authorization failures for ACL and organization-guard cases must assert SQLSTATE `42501`; any other error fails the verifier. For successful artifact behavior, capture `ROW_COUNT` and query persisted state: draft/rejected updates each affect one and persist, their combined delete affects exactly two and leaves neither row, and the non-approved parent cascade removes its child artifact. This prevents an unrelated FK/RLS error from satisfying the test.
 
-For quota attribution, enqueue `job_id` in `source_org_id` with one usage item `{ "category": "quiz_generation", "quantity": 1, "referenceId": "verify:quota" }`. Record the job organization and matching ledger count, reassign the lesson to `target_org_id` through the service-role maintenance path, and perform the existing retry transition on that job. Assert afterward that:
+For quota attribution, enqueue `job_id` in `source_org_id` with one usage item `{ "category": "quiz_generation", "quantity": 1, "referenceId": "verify:quota" }`, claim it, and move it to a deterministic failed state through an owned unexpired lease. After a real lesson reassignment, retry, reclaim, and complete that original job. Assert afterward that:
 
 - the job still owns `source_org_id`;
 - the usage row still owns `source_org_id`;
 - exactly one `verify:quota` usage reservation exists;
 - no matching target-organization reservation was created.
 
-Use this exact enqueue shape so the verifier exercises the real quota RPC rather than a direct fixture insert:
-
-```sql
-SELECT public.enqueue_content_jobs_with_usage(
-  :'source_org_id'::uuid,
-  :'teacher_user_id'::uuid,
-  jsonb_build_array(jsonb_build_object(
-    'id', :'job_id',
-    'batch_id', :'batch_id',
-    'lesson_id', :'lesson_id',
-    'objective_id', :'objective_id',
-    'requested_by', :'teacher_user_id',
-    'job_type', 'generate_structured_quiz',
-    'idempotency_key', 'verify:quota',
-    'input', '{}'::jsonb
-  )),
-  jsonb_build_array(jsonb_build_object(
-    'category', 'quiz_generation',
-    'quantity', 1,
-    'referenceId', 'verify:quota'
-  ))
-);
-```
-
-The upload-RPC case must use the complete contract and materialize its return value for assertions:
-
-```sql
-CREATE TEMP TABLE verification_upload_result (payload jsonb) ON COMMIT DROP;
-GRANT INSERT, SELECT ON verification_upload_result TO service_role;
-
--- Run this INSERT only after setting service-role claims and SET LOCAL ROLE service_role.
-INSERT INTO pg_temp.verification_upload_result (payload)
-SELECT public.create_uploaded_lesson_artifact(
-  :'source_org_id'::uuid,
-  :'teacher_user_id'::uuid,
-  'verify:upload',
-  jsonb_build_object(
-    'id', :'upload_asset',
-    'lesson_id', :'lesson_id',
-    'objective_id', :'objective_id',
-    'asset_type', 'uploaded_media',
-    'storage_bucket', 'lesson-assets',
-    'storage_path', 'verification/' || :'upload_asset',
-    'mime_type', 'image/png',
-    'byte_size', 1,
-    'checksum_sha256', repeat('a', 64),
-    'original_filename', 'verification.png',
-    'alt_text', 'Verification image',
-    'caption', '',
-    'processing_status', 'ready'
-  ),
-  jsonb_build_object(
-    'id', :'upload_artifact',
-    'lesson_id', :'lesson_id',
-    'objective_id', :'objective_id',
-    'objective_revision', 1,
-    'kind', 'uploaded_media',
-    'position', 9,
-    'payload', jsonb_build_object('assetId', :'upload_asset')
-  ),
-  jsonb_build_object(
-    'id', :'upload_job_id',
-    'batch_id', :'upload_batch_id',
-    'lesson_id', :'lesson_id',
-    'objective_id', :'objective_id',
-    'job_type', 'extract_media',
-    'idempotency_key', 'verify:upload-job',
-    'input', '{}'::jsonb
-  )
-) AS payload;
-```
-
-After `RESET ROLE`, assert `payload #>> '{asset,id}'`, `payload #>> '{artifact,id}'`, and `payload #>> '{job,id}'` equal their deterministic IDs, and confirm all three rows exist before continuing. Creating the temp table as the migration owner before role switching avoids cross-role ownership failures.
+The exact template calls the real enqueue and upload RPCs, checks the upload payload directly in a CTE, and then verifies the persisted asset, artifact, job, and usage rows. Do not replace those calls with direct fixture inserts or a temp-table variant; the source-equality test intentionally rejects alternate implementations.
 
 - [ ] **Step 4: Verify the checked-in contract**
 
 Run:
 
 ```powershell
-pnpm exec vitest run src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts src/lib/lesson-artifacts/__tests__/database-verifier-contract.test.ts
 git diff --check
 ```
 
-Expected: PASS. This source contract only guards that the intended matrix remains checked in; PostgreSQL execution in Step 6 is the sole proof that the verifier and migration behave correctly.
+Expected: PASS. This source contract only guards that the intended matrix remains checked in; it is not sufficient for commit or merge readiness.
 
-- [ ] **Step 5: Commit Task 5**
+- [ ] **Step 5: Run the mandatory pre-merge PostgreSQL database gate**
 
-```powershell
-git add supabase/verification/0035_harden_lesson_artifact_writes.sql src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
-git commit -m "test(db): add hardening verifier"
-```
+For the full DML matrix, use direct migration-owner connections to two distinct isolated disposable databases that are still at `0034`. Expect exit code `0`, no assertion raises, and the DML transaction rolls back. Run against both:
 
-- [ ] **Step 6: Run the production-rollout database gate when direct environments are available**
-
-For the full DML matrix, use direct migration-owner connections to isolated, empty disposable environments. Expect exit code `0`, no assertion raises, and the transaction rolls back. Run against both:
-
-- a clean environment provisioned from the operator's canonical `0034` schema baseline, after applying `0035`;
-- an isolated upgrade clone already at `0034`, after applying only `0035`.
+- a clean environment provisioned from the operator's canonical `0034` schema baseline, in `canonical` mode;
+- an isolated representative upgrade-state clone already at `0034`, in `upgrade` mode.
 
 Do not call the first environment a raw full-chain replay; the known `0021` typo makes that a separate migration-history repair.
 
-Use the two operator-provided direct URLs explicitly:
+Use the two operator-provided direct URLs explicitly. The runner itself validates the `0034` prerequisite, applies `0035`, runs the read-only catalog verifier, and runs the rollback-only DML verifier:
 
 ```powershell
-$env:DATABASE_URL = $env:BASELINE_DATABASE_URL
-psql $env:DATABASE_URL -X -v ON_ERROR_STOP=1 -v run_dml=true -f 'supabase\verification\0035_harden_lesson_artifact_writes.sql'
-$env:DATABASE_URL = $env:UPGRADE_DATABASE_URL
-psql $env:DATABASE_URL -X -v ON_ERROR_STOP=1 -v run_dml=true -f 'supabase\verification\0035_harden_lesson_artifact_writes.sql'
+pwsh -NoProfile -File scripts/verify-0035.ps1 -DisposableDatabaseUrl $env:BASELINE_0034_DATABASE_URL -Mode canonical -ConfirmDisposable
+pwsh -NoProfile -File scripts/verify-0035.ps1 -DisposableDatabaseUrl $env:UPGRADE_0034_DATABASE_URL -Mode upgrade -ConfirmDisposable
 ```
 
-The repository has no `supabase/config.toml`, migration-runner command, canonical baseline, or disposable database harness. Therefore the operator must provide `BASELINE_DATABASE_URL`, `UPGRADE_DATABASE_URL`, and the canonical `0034` baseline externally. Record both platform migration results and both verifier exit codes in rollout evidence; do not describe them as repo-automated CI.
+The repository has no `supabase/config.toml`, migration-runner command, canonical baseline, or disposable database harness. Therefore the operator must provide `BASELINE_0034_DATABASE_URL`, `UPGRADE_0034_DATABASE_URL`, and the canonical `0034` baseline externally. Record both runner exit codes in rollout evidence; do not describe them as repo-automated CI.
 
-After the migration reaches a shared staging or production target, run catalog-only mode; it must not create fixtures or call `claim_content_jobs`:
+Both commands must print their mode-specific success message and exit `0` before commit or merge. If either direct URL, `psql`, clone, or canonical baseline is unavailable, record database verification as blocked and stop; source-contract tests do not make the change merge-ready. Never pass a shared staging or production URL to the runner.
+
+After either isolated run, any change to migration `0035`, the prerequisite SQL, either verifier SQL file, the authoritative DML template, or the runner invalidates both results. Reprovision fresh `0034` canonical and upgrade clones and rerun both commands. Discard a clone already advanced to `0035`; do not bypass the `0034` prerequisite.
+
+- [ ] **Step 6: Commit Task 5 after PostgreSQL verification**
 
 ```powershell
-psql $env:DATABASE_URL -X -v ON_ERROR_STOP=1 -v run_dml=false -f 'supabase\verification\0035_harden_lesson_artifact_writes.sql'
+git add supabase/migrations/0035_harden_lesson_artifact_writes.sql supabase/verification/0034_prerequisites.sql supabase/verification/0035_catalog.sql supabase/verification/0035_dml.sql scripts/verify-0035.ps1 src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts src/lib/lesson-artifacts/__tests__/database-verifier-contract.test.ts
+git commit -m "fix(db): verify lesson write hardening"
 ```
-
-This is a production-rollout gate, not a merge blocker.
 
 ---
 
@@ -1155,7 +1373,7 @@ This is a production-rollout gate, not a merge blocker.
 - [ ] **Step 1: Run all focused regression tests together**
 
 ```powershell
-pnpm exec vitest run src/lib/lesson-artifacts/__tests__/lesson-update.test.ts src/lib/lesson-artifacts/__tests__/lesson-update-route.test.ts src/lib/lesson-artifacts/__tests__/lesson-route-contract.test.ts src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/lesson-update.test.ts src/lib/lesson-artifacts/__tests__/lesson-update-route.test.ts src/lib/lesson-artifacts/__tests__/lesson-route-contract.test.ts src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts src/lib/lesson-artifacts/__tests__/database-verifier-contract.test.ts
 ```
 
 Expected: all focused files pass with zero failed tests.
@@ -1185,14 +1403,19 @@ Confirm:
 
 - [ ] **Step 4: Deploy in the required order**
 
-1. Apply migration `0035` to the isolated upgrade clone and require the full `run_dml=true` verifier to exit `0`.
-2. Apply migration `0035` to the shared target.
-3. Run `run_dml=false` catalog-only verification on the shared target and require exit `0`.
-4. Confirm bundle generation, regeneration/retry, upload extraction, cancellation, and worker progression still succeed through service-role paths.
-5. Deploy the application route/form changes.
-6. Edit an existing lesson without choosing an organization and verify its `organization_id` remains unchanged.
+1. Confirm both mandatory isolated runner modes exited `0` against fresh `0034` clones and that no verifier input changed afterward.
+2. Deploy the omission-aware route and form to the shared target without applying `0035`.
+3. Edit an existing lesson and verify its `organization_id` remains unchanged; do not release reassignment during this compatibility window.
+4. Apply migration `0035` to the shared target.
+5. Run catalog-only verification and require exit `0`:
+
+```powershell
+psql $env:SHARED_DATABASE_URL -X --set ON_ERROR_STOP=1 --file 'supabase\verification\0035_catalog.sql'
+```
+
+6. Confirm bundle generation, regeneration/retry, upload extraction, cancellation, and worker progression through service-role paths.
 7. Exercise one authorized reassignment and one insufficient-role reassignment; expect success and `403`, respectively.
 
-- [ ] **Step 5: Monitor and recover forward-only**
+- [ ] **Step 5: Monitor and recover safely**
 
-Monitor permission errors, lesson PUT `400/403/500` rates, queued jobs that stop progressing, and worker failures. If a defect appears, roll back the application bundle if useful, but repair database behavior with a new forward migration. Never restore authenticated job writes, null organization detachment, or `RETURN NEW` for artifact deletes.
+Monitor permission errors, lesson PUT `400/403/500` rates, queued jobs, and worker failures. Before shared-target `0035`, the compatibility application may be rolled back normally. After `0035`, never restore a pre-compatible route/form because it sends `organization_id = null` and recreates the lesson-edit outage. Recover forward with an omission-safe application or corrective migration while retaining job-write restrictions, the lesson column allowlist, null-detachment prevention, and the corrected artifact-delete return.

--- a/docs/superpowers/plans/2026-07-12-pr-13-review-fixes.md
+++ b/docs/superpowers/plans/2026-07-12-pr-13-review-fixes.md
@@ -1,0 +1,1198 @@
+# PR 13 Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three unresolved PR #13 review findings by making content jobs server-write-only, preserving and authorizing lesson organization ownership, and restoring deletion of non-approved lesson artifacts.
+
+**Architecture:** Put request-shape and organization-transfer decisions in a small, side-effect-free lesson-update module, while the lesson route remains the I/O coordinator. Keep the final lesson mutation on the authenticated Supabase client and use a service-role client only to read membership evidence. Add a forward-only `0035` migration as the atomic database boundary for job privileges, organization reassignment, and artifact immutability, plus a transactional SQL acceptance script for environments where the migration is applied.
+
+**Tech Stack:** Next.js 16, TypeScript 5.9, Zod 3, Supabase/PostgreSQL RLS and trigger functions, Vitest 4, pnpm 10, PowerShell/psql rollout commands.
+
+**Approved design:** `docs/superpowers/specs/2026-07-11-pr-13-review-fixes-design.md`
+
+## Global Constraints
+
+- Do not modify already-applied migrations `0033_objective_artifacts.sql` or `0034_normalize_lesson_teacher_ownership.sql`.
+- Authenticated and anonymous database roles must never regain direct `INSERT`, `UPDATE`, or `DELETE` access to `content_jobs`.
+- Omitted `organizationId` preserves ownership; explicit `null` and malformed UUIDs are rejected; edit mode must omit the property entirely.
+- A real teacher reassignment requires active `owner` or `admin` membership in the current organization, when present, and the target organization. A global admin is exempt from membership checks.
+- The route may use `createServerSupabase()` only for trusted membership reads. The final lesson update must use `createSSRUserSupabase()` so the database trigger sees the authenticated actor.
+- Existing job reservations remain attributed to their original organization. No backfill or transfer of queued/running jobs is in scope.
+- Source-contract tests supplement behavioral tests; they are not the sole proof of route or database behavior.
+- Apply each production change only after its focused regression test fails for the expected reason.
+
+## Planning Discoveries and Scope Boundaries
+
+- The raw historical migration chain is not replayable: `0021_add_teacherid_to_lessons_assessments.sql` creates `teacher_id` but indexes nonexistent `teacherid` columns. This task must not rewrite that applied file. A clean-environment gate therefore starts from an operator-provided canonical schema baseline at `0034`, then applies `0035`. Repairing historical replay or checking in a new baseline is a separate migration-governance decision.
+- `enable_rls_migration.sql` contains legacy `lessons.teacher`/`admins` update policies. Migration `0035` must replace those lesson manager policies with `can_manage_lesson(id)` policies so normalized teacher/admin updates can reach the new organization trigger.
+- `claim_content_jobs` claims globally, not by fixture ID. Full DML verification is allowed only on an isolated disposable database with no pre-existing queued/running jobs. Shared staging and production may run catalog-only verification, never the claim/DML matrix.
+
+---
+
+### Task 1: Define lesson-update and transfer policy as testable functions
+
+**Files:**
+- Create: `src/lib/lesson-update.ts`
+- Create: `src/lib/lesson-artifacts/__tests__/lesson-update.test.ts`
+
+**Interfaces:**
+- Produces: `updateLessonSchema` and `LessonUpdateInput`.
+- Produces: `mapLessonUpdate(input, updatedAt)` with conditional `organization_id` ownership.
+- Produces: `requiredOrganizationAdminIds(input)` and `hasRequiredOrganizationAdminMemberships(requiredIds, memberships)`.
+- Consumes: the existing API fields `title`, `subject`, `gradeLevel`, `objectives`, `content`, and optional non-null `organizationId`.
+
+- [ ] **Step 1: Write the failing schema and mapper tests**
+
+Cover valid omission and UUID values, then assert `null` and malformed values fail parsing. Prove ownership with `Object.hasOwn`, not only value equality:
+
+```ts
+const common = {
+  title: 'Fractions',
+  subject: 'Mathematics',
+  gradeLevel: 'JHS 1',
+  objectives: ['Compare fractions'],
+  content: 'Lesson body',
+};
+
+const omitted = mapLessonUpdate(updateLessonSchema.parse(common), '2026-07-12T10:00:00.000Z');
+expect(Object.hasOwn(omitted, 'organization_id')).toBe(false);
+
+const explicit = mapLessonUpdate(
+  updateLessonSchema.parse({ ...common, organizationId: '11111111-1111-4111-8111-111111111111' }),
+  '2026-07-12T10:00:00.000Z',
+);
+expect(explicit.organization_id).toBe('11111111-1111-4111-8111-111111111111');
+expect(Object.hasOwn(mapLessonUpdate({ ...common, organizationId: undefined }, '2026-07-12T10:00:00.000Z'), 'organization_id')).toBe(false);
+expect(() => updateLessonSchema.parse({ ...common, organizationId: null })).toThrow();
+expect(() => updateLessonSchema.parse({ ...common, organizationId: 'not-a-uuid' })).toThrow();
+```
+
+- [ ] **Step 2: Write the failing organization-authorization matrix**
+
+Test these states before implementation:
+
+| Actor/update | Required IDs | Membership result |
+|---|---:|---|
+| Teacher, property omitted | `[]` | no lookup required |
+| Teacher, same UUID | `[]` | no lookup required |
+| Global admin, real change | `[]` | membership bypass |
+| Teacher, null current to target | target only | active target owner/admin required |
+| Teacher, source to target | source and target | both active owner/admin required |
+| Inactive, `member`, or missing row | unchanged required IDs | rejected |
+
+Use role strings from `DBOrganizationMember` and include owner-success, admin-success, mixed-role success, missing-source, missing-target, inactive, and ordinary-member cases.
+
+- [ ] **Step 3: Verify the new test fails**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/lesson-update.test.ts
+```
+
+Expected: FAIL because `@/lib/lesson-update` does not exist.
+
+- [ ] **Step 4: Implement the minimal policy module**
+
+Keep the Zod schema non-nullable and use an allowlisted database row:
+
+```ts
+export const updateLessonSchema = z.object({
+  title: z.string().trim().min(1).max(160),
+  subject: z.string().trim().min(1).max(120),
+  gradeLevel: z.string().trim().min(1).max(80),
+  objectives: z.array(z.string().trim().min(1).max(500)).min(1).max(20),
+  content: z.string().max(100_000).nullable().default(null),
+  organizationId: z.string().uuid().optional(),
+});
+
+export type LessonUpdateInput = z.infer<typeof updateLessonSchema>;
+
+export function mapLessonUpdate(input: LessonUpdateInput, updatedAt: string) {
+  const row: {
+    title: string;
+    subject: string;
+    gradelevel: string;
+    objectives: string[];
+    content: string | null;
+    updated_at: string;
+    organization_id?: string;
+  } = {
+    title: input.title,
+    subject: input.subject,
+    gradelevel: input.gradeLevel,
+    objectives: input.objectives,
+    content: input.content,
+    updated_at: updatedAt,
+  };
+  if (Object.hasOwn(input, 'organizationId') && input.organizationId !== undefined) {
+    row.organization_id = input.organizationId;
+  }
+  return row;
+}
+```
+
+Define the transfer helpers with these exact boundaries so omission remains distinguishable from a supplied value:
+
+```ts
+export type OrganizationAdminMembership = Pick<
+  DBOrganizationMember,
+  'organization_id' | 'role' | 'is_active'
+>;
+```
+
+Implement the exact function signatures and bodies below without I/O:
+
+```ts
+export function requiredOrganizationAdminIds(input: {
+  actorRole: string | null;
+  currentOrganizationId: string | null;
+  update: Pick<LessonUpdateInput, 'organizationId'>;
+}): string[] {
+  if (!Object.hasOwn(input.update, 'organizationId')) return [];
+  const target = input.update.organizationId;
+  if (!target || target === input.currentOrganizationId || input.actorRole === 'admin') return [];
+  return [...new Set([input.currentOrganizationId, target].filter((id): id is string => Boolean(id)))];
+}
+
+export function hasRequiredOrganizationAdminMemberships(
+  requiredIds: string[],
+  memberships: OrganizationAdminMembership[],
+): boolean {
+  return requiredIds.every((organizationId) => memberships.some((membership) => (
+    membership.organization_id === organizationId
+    && membership.is_active
+    && (membership.role === 'owner' || membership.role === 'admin')
+  )));
+}
+```
+
+This returns deduplicated IDs only for real teacher reassignments and treats typed `organizationId: undefined` as omission. Import `DBOrganizationMember` with `import type` so the module has no database/runtime dependency.
+
+- [ ] **Step 5: Verify Task 1**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/lesson-update.test.ts
+pnpm typecheck
+```
+
+Expected: PASS; omission, UUID inclusion, no-op/admin lookup bypass, and the full membership matrix are deterministic.
+
+- [ ] **Step 6: Commit Task 1**
+
+```powershell
+git add src/lib/lesson-update.ts src/lib/lesson-artifacts/__tests__/lesson-update.test.ts
+git commit -m "feat(lessons): define update policy"
+```
+
+---
+
+### Task 2: Make the lesson PUT route preserve ownership and preauthorize transfers
+
+**Files:**
+- Modify: `src/app/api/lessons/[lessonId]/route.ts`
+- Create: `src/lib/lesson-artifacts/__tests__/lesson-update-route.test.ts`
+- Modify: `src/lib/lesson-artifacts/__tests__/lesson-route-contract.test.ts`
+
+**Interfaces:**
+- Consumes: `updateLessonSchema`, `mapLessonUpdate`, `requiredOrganizationAdminIds`, and `hasRequiredOrganizationAdminMemberships` from `@/lib/lesson-update`.
+- Consumes: authenticated user client from `createSSRUserSupabase()` and trusted membership reader from `createServerSupabase()`.
+- Produces: `400` for invalid/null organization input, `403` for insufficient transfer authority, `500` for membership-read failures, and no lesson mutation on any of those failures.
+
+- [ ] **Step 1: Build a failing route-test harness**
+
+Use `vi.mock` for `@/lib/auth` and `@/lib/supabase.server`. Provide separate fluent query doubles for:
+
+- the authenticated lesson lookup, teacher lookup, and final update;
+- the trusted `organization_members` lookup;
+- update call tracking so rejected requests can assert `.update()` was never called.
+
+Call `PUT` with a `Request` cast to the route's accepted request type and `{ params: Promise.resolve({ lessonId: 'lesson-1' }) }`.
+
+Use a thenable chain so the route can await any terminal Supabase call without teaching the test every implementation detail:
+
+```ts
+function queryResult<T>(result: T) {
+  const chain: Record<string, any> = {};
+  for (const method of ['select', 'eq', 'in', 'update', 'maybeSingle']) {
+    chain[method] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (value: T) => unknown, reject: (reason: unknown) => unknown) => (
+    Promise.resolve(result).then(resolve, reject)
+  );
+  return chain;
+}
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  createSSRUserSupabase: vi.fn(),
+  createServerSupabase: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({ getServerSession: mocks.getServerSession }));
+vi.mock('@/lib/supabase.server', () => ({
+  createSSRUserSupabase: mocks.createSSRUserSupabase,
+  createServerSupabase: mocks.createServerSupabase,
+}));
+```
+
+Reset mocks and modules before each case, configure table-specific query queues, then dynamically import the route. Never import the route before mocks are installed.
+
+- [ ] **Step 2: Write the failing route behavior matrix**
+
+Add focused tests for:
+
+1. omitted `organizationId`: trusted client is never created and the update row does not own `organization_id`;
+2. same organization UUID: trusted membership query is skipped;
+3. teacher with active source/target owner/admin rows: update succeeds;
+4. inactive, ordinary-member, missing-source, or missing-target evidence: `403`, update never called;
+5. current organization is null: only target evidence is queried;
+6. global admin: membership query is bypassed and update succeeds;
+7. membership query error: `500`, update never called;
+8. explicit `null` or malformed UUID: `400`, update never called;
+9. database guard returns SQLSTATE `42501`: route returns `403` rather than exposing it as `500`.
+
+- [ ] **Step 3: Update the supplemental source contract to fail on unsafe wiring**
+
+Replace the assertion that currently requires inline `organization_id: body.organizationId` with boundary assertions:
+
+```ts
+expect(route).not.toContain('organization_id: body.organizationId ?? null');
+expect(route).toContain('mapLessonUpdate(');
+expect(route).toContain('createServerSupabase');
+expect(route).toContain('createSSRUserSupabase');
+expect(route).toContain(".select('id, teacher_id, organization_id')");
+```
+
+The behavioral route test remains the primary proof that the trusted client does not perform the update.
+
+- [ ] **Step 4: Verify the route tests fail for the expected reasons**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/lesson-update-route.test.ts src/lib/lesson-artifacts/__tests__/lesson-route-contract.test.ts
+```
+
+Expected: FAIL because the route still accepts `null`, clears omitted organization ownership, and has no transfer membership orchestration.
+
+- [ ] **Step 5: Implement route orchestration with explicit client roles**
+
+In `PUT`:
+
+1. rename the current client to `userSupabase`;
+2. select `id, teacher_id, organization_id` for the existing lesson;
+3. retain the existing teacher-owner/global-admin lesson manager check;
+4. parse the body with the shared schema;
+5. compute required source/target organization IDs;
+6. only when IDs are required, create `trustedSupabase` and query:
+
+```ts
+const { data: memberships, error: membershipError } = await trustedSupabase
+  .from('organization_members')
+  .select('organization_id, role, is_active')
+  .eq('user_id', session.user.id)
+  .in('organization_id', requiredOrganizationIds);
+```
+
+7. return `403` before mutation if any required ID lacks an active owner/admin row;
+8. call `userSupabase.from('lessons').update(mapLessonUpdate(body, new Date().toISOString()))`;
+9. map a returned database error with code `42501` to `403` because it represents the atomic guard rejecting a raced or direct unauthorized transfer;
+10. return a Zod-specific `400` response in the catch block and retain the existing generic database failure behavior otherwise. Use stable client-facing errors: `Not authorized to reassign this lesson organization` for transfer `403`, `Invalid lesson update` for `400`, and the existing generic `Failed to update lesson` for unexpected `500`.
+
+- [ ] **Step 6: Verify Task 2**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/lesson-update.test.ts src/lib/lesson-artifacts/__tests__/lesson-update-route.test.ts src/lib/lesson-artifacts/__tests__/lesson-route-contract.test.ts
+pnpm typecheck
+```
+
+Expected: PASS; all rejected paths are mutation-free, and only real teacher transfers read memberships through the trusted client.
+
+- [ ] **Step 7: Commit Task 2**
+
+```powershell
+git add -- 'src/app/api/lessons/[lessonId]/route.ts' src/lib/lesson-artifacts/__tests__/lesson-update-route.test.ts src/lib/lesson-artifacts/__tests__/lesson-route-contract.test.ts
+git commit -m "fix(lessons): guard organization changes"
+```
+
+---
+
+### Task 3: Keep organization ownership out of edit-form payloads
+
+**Files:**
+- Modify: `src/lib/lesson-artifacts/authoring-ui.ts`
+- Modify: `src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts`
+- Modify: `src/components/lessons/CreateLessonForm.tsx`
+
+**Interfaces:**
+- Produces: `LessonSubmissionFields` and `buildLessonSubmissionPayload(fields, operation)`.
+- Consumes: `{ mode: 'edit' } | { mode: 'create'; organizationId: string }`.
+
+- [ ] **Step 1: Write failing create/edit payload tests**
+
+Use a frozen common-fields fixture and assert:
+
+```ts
+const editPayload = buildLessonSubmissionPayload(fields, { mode: 'edit' });
+expect(editPayload).toEqual(fields);
+expect(Object.hasOwn(editPayload, 'organizationId')).toBe(false);
+expect(Object.hasOwn(JSON.parse(JSON.stringify(editPayload)), 'organizationId')).toBe(false);
+
+expect(buildLessonSubmissionPayload(fields, {
+  mode: 'create',
+  organizationId: '11111111-1111-4111-8111-111111111111',
+})).toEqual({ ...fields, organizationId: '11111111-1111-4111-8111-111111111111' });
+
+expect(buildLessonSubmissionPayload(fields, {
+  mode: 'create',
+  organizationId: '',
+})).toEqual({ ...fields, organizationId: null });
+```
+
+In the same test file, add a supplemental wiring contract using `readFile` and `join`:
+
+```ts
+const form = await readFile(
+  join(process.cwd(), 'src', 'components', 'lessons', 'CreateLessonForm.tsx'),
+  'utf8',
+);
+expect(form).toContain('buildLessonSubmissionPayload');
+expect(form).toContain("{ mode: 'edit' }");
+expect(form).toContain("{ mode: 'create', organizationId }");
+expect(form).not.toContain('organizationId: organizationId || null');
+```
+
+- [ ] **Step 2: Verify the helper test fails**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts
+```
+
+Expected: FAIL because `buildLessonSubmissionPayload` is not exported and the form still constructs the organization field inline.
+
+- [ ] **Step 3: Implement the discriminated payload helper**
+
+```ts
+export type LessonSubmissionFields = {
+  title: string;
+  subject: string;
+  gradeLevel: string;
+  objectives: string[];
+  content: string;
+};
+
+export function buildLessonSubmissionPayload(
+  fields: LessonSubmissionFields,
+  operation: { mode: 'edit' } | { mode: 'create'; organizationId: string },
+): LessonSubmissionFields & { organizationId?: string | null } {
+  if (operation.mode === 'edit') return { ...fields };
+  return { ...fields, organizationId: operation.organizationId || null };
+}
+```
+
+The discriminated union prevents an edit operation from accepting an organization argument.
+
+- [ ] **Step 4: Wire the form through the helper**
+
+Build the common fields once, then pass either `{ mode: 'edit' }` or `{ mode: 'create', organizationId }` to the helper before `JSON.stringify`:
+
+```ts
+const payload = buildLessonSubmissionPayload(
+  { title, subject, gradeLevel, objectives, content: generatedContent },
+  isEditing ? { mode: 'edit' } : { mode: 'create', organizationId },
+);
+
+const response = await fetch(url, {
+  method,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(payload),
+});
+```
+
+Keep the existing create behavior and organization selector unchanged.
+
+- [ ] **Step 5: Verify Task 3**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts
+pnpm typecheck
+pnpm exec eslint src/components/lessons/CreateLessonForm.tsx src/lib/lesson-artifacts/authoring-ui.ts src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts
+```
+
+Expected: PASS; create owns and serializes `organizationId`, while edit does neither.
+
+- [ ] **Step 6: Commit Task 3**
+
+```powershell
+git add src/lib/lesson-artifacts/authoring-ui.ts src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts src/components/lessons/CreateLessonForm.tsx
+git commit -m "fix(lessons): preserve edit ownership"
+```
+
+---
+
+### Task 4: Add the forward database hardening migration
+
+**Files:**
+- Create: `supabase/migrations/0035_harden_lesson_artifact_writes.sql`
+- Create: `src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts`
+
+**Interfaces:**
+- Changes: `content_jobs` policies and table privileges.
+- Replaces: legacy lesson manager RLS policies with normalized manager policies and a NEW-row owner check.
+- Reasserts: service-role-only execution for the three content-job-mutating RPCs.
+- Replaces: `public.prevent_approved_artifact_mutation()` and `lesson_artifacts_approved_immutable`.
+- Produces: `public.prevent_invalid_lesson_organization_reassignment()` and `lessons_organization_reassignment_guard`.
+
+- [ ] **Step 1: Write the failing migration contract test**
+
+Read both `0033_objective_artifacts.sql` and `0035_harden_lesson_artifact_writes.sql`, lowercase them, and require all of these contracts:
+
+- `0033` defines `content_jobs_select_own`, while `0035` drops `content_jobs_insert_own` and `content_jobs_update_own` and does not drop the select policy;
+- `0035` enables lesson RLS, defines `can_assign_lesson_teacher(uuid)`, and makes `lessons_manager_update` use `can_manage_lesson(id)` for `USING` plus `can_assign_lesson_teacher(teacher_id)` for `WITH CHECK`;
+- revoke all table privileges from `PUBLIC`, `anon`, and `authenticated`;
+- grant `SELECT` to `authenticated` and `SELECT, INSERT, UPDATE, DELETE` to `service_role`;
+- revoke `PUBLIC`, `anon`, and `authenticated` execute rights and grant `service_role` execute rights for the exact signatures:
+  - `claim_content_jobs(text, integer, integer)`;
+  - `enqueue_content_jobs_with_usage(uuid, uuid, jsonb, jsonb)`;
+  - `create_uploaded_lesson_artifact(uuid, uuid, text, jsonb, jsonb, jsonb)`;
+- enable RLS on `public.lessons`, drop legacy `lessons_teacher_own` and `lessons_admin_all`, then idempotently create `lessons_manager_select`, `lessons_manager_update`, and `lessons_manager_delete`; update `USING` checks old-row management and `WITH CHECK` validates the NEW `teacher_id` through `can_assign_lesson_teacher(teacher_id)`;
+- artifact trigger function branches on `TG_OP = 'DELETE'`, returning `OLD` for delete and `NEW` for update;
+- both affected triggers are dropped and recreated;
+- organization trigger is `BEFORE UPDATE OF organization_id` and contains service-role bypass, `can_manage_lesson(OLD.id)`, null rejection, global-admin bypass, active owner/admin source/target checks, and SQLSTATE `42501` on every rejection.
+
+- [ ] **Step 2: Verify the migration test fails**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+```
+
+Expected: FAIL because migration `0035` does not exist.
+
+- [ ] **Step 3: Implement the content-job privilege boundary**
+
+Use explicit, idempotent policy drops and literal ACLs:
+
+```sql
+DROP POLICY IF EXISTS content_jobs_insert_own ON public.content_jobs;
+DROP POLICY IF EXISTS content_jobs_update_own ON public.content_jobs;
+
+REVOKE ALL PRIVILEGES ON TABLE public.content_jobs FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.content_jobs TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.content_jobs TO service_role;
+```
+
+For each exact job-mutating RPC signature, `REVOKE ALL ... FROM PUBLIC, anon, authenticated` and `GRANT EXECUTE ... TO service_role`. Do not alter quota calculations, idempotency behavior, or existing rows.
+
+In the same forward migration, enable RLS, add a hardened NEW-row owner predicate, and replace the legacy lesson manager policies without restoring direct lesson inserts:
+
+```sql
+ALTER TABLE public.lessons ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.can_assign_lesson_teacher(p_teacher_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+  SELECT auth.role() = 'service_role'
+    OR EXISTS (
+      SELECT 1 FROM public.teachers t
+      WHERE t.id = p_teacher_id AND t.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM public.users u
+      WHERE u.id = auth.uid() AND u.role = 'admin'
+    );
+$$;
+
+REVOKE ALL ON FUNCTION public.can_assign_lesson_teacher(uuid)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.can_assign_lesson_teacher(uuid)
+  TO authenticated, service_role;
+
+DROP POLICY IF EXISTS lessons_teacher_own ON public.lessons;
+DROP POLICY IF EXISTS lessons_admin_all ON public.lessons;
+DROP POLICY IF EXISTS lessons_manager_select ON public.lessons;
+DROP POLICY IF EXISTS lessons_manager_update ON public.lessons;
+DROP POLICY IF EXISTS lessons_manager_delete ON public.lessons;
+
+CREATE POLICY lessons_manager_select ON public.lessons
+  FOR SELECT TO authenticated
+  USING (public.can_manage_lesson(id));
+
+CREATE POLICY lessons_manager_update ON public.lessons
+  FOR UPDATE TO authenticated
+  USING (public.can_manage_lesson(id))
+  WITH CHECK (public.can_assign_lesson_teacher(teacher_id));
+
+CREATE POLICY lessons_manager_delete ON public.lessons
+  FOR DELETE TO authenticated
+  USING (public.can_manage_lesson(id));
+```
+
+Keep the existing student and broad teacher read policies. Lesson creation remains service-role-only through `create_lesson_draft`; do not add an authenticated insert policy. The NEW-row predicate must have tests proving a teacher cannot change `teacher_id`, while a global admin can perform an intentional ownership change.
+
+- [ ] **Step 4: Repair approved-artifact trigger returns**
+
+Replace the function in place:
+
+```sql
+IF OLD.status = 'approved' THEN
+  RAISE EXCEPTION 'Approved lesson artifacts are immutable; create a new version';
+END IF;
+IF TG_OP = 'DELETE' THEN
+  RETURN OLD;
+END IF;
+RETURN NEW;
+```
+
+Drop and recreate `lesson_artifacts_approved_immutable` as `BEFORE UPDATE OR DELETE` so drifted environments converge on the same attachment.
+
+- [ ] **Step 5: Add the atomic lesson-organization guard**
+
+Create the guard with a hardened search path and fully qualified non-catalog references:
+
+```sql
+CREATE OR REPLACE FUNCTION public.prevent_invalid_lesson_organization_reassignment()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
+BEGIN
+  IF auth.role() = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NOT public.can_manage_lesson(OLD.id) THEN
+    RAISE EXCEPTION 'Not authorized to reassign lesson organization'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.organization_id IS NULL THEN
+    RAISE EXCEPTION 'Lesson organization cannot be cleared'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NEW.organization_id IS NOT DISTINCT FROM OLD.organization_id THEN
+    RETURN NEW;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.users u
+    WHERE u.id = auth.uid() AND u.role = 'admin'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  IF OLD.organization_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.organization_members m
+    WHERE m.organization_id = OLD.organization_id
+      AND m.user_id = auth.uid()
+      AND m.is_active = true
+      AND m.role IN ('owner', 'admin')
+  ) THEN
+    RAISE EXCEPTION 'Active owner or admin membership in current organization is required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.organization_members m
+    WHERE m.organization_id = NEW.organization_id
+      AND m.user_id = auth.uid()
+      AND m.is_active = true
+      AND m.role IN ('owner', 'admin')
+  ) THEN
+    RAISE EXCEPTION 'Active owner or admin membership in target organization is required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.prevent_invalid_lesson_organization_reassignment()
+  FROM PUBLIC, anon, authenticated;
+```
+
+The null check intentionally precedes the same-value return so an authenticated statement that explicitly sets a legacy null organization to null is rejected. `service_role` remains the only null-maintenance bypass. Drop and recreate `lessons_organization_reassignment_guard` as:
+
+```sql
+CREATE TRIGGER lessons_organization_reassignment_guard
+BEFORE UPDATE OF organization_id ON public.lessons
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_invalid_lesson_organization_reassignment();
+```
+
+- [ ] **Step 6: Verify Task 4**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+pnpm exec eslint src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+git status --short -- supabase/migrations
+git diff --check
+```
+
+Expected: tests and lint pass; migration status lists only `?? supabase/migrations/0035_harden_lesson_artifact_writes.sql`; whitespace check passes.
+
+- [ ] **Step 7: Commit Task 4**
+
+```powershell
+git add supabase/migrations/0035_harden_lesson_artifact_writes.sql src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+git commit -m "fix(db): harden lesson artifact writes"
+```
+
+---
+
+### Task 5: Add the transactional database acceptance gate
+
+**Files:**
+- Create: `supabase/verification/0035_harden_lesson_artifact_writes.sql`
+- Modify: `src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts`
+
+**Interfaces:**
+- Consumes: `run_dml=false` for catalog-only checks on a migrated environment, or `run_dml=true` plus a direct migration-owner connection to an isolated disposable database that can `SET ROLE authenticated` and `SET ROLE service_role`.
+- Produces: a non-zero `psql` exit on any catalog, privilege, trigger, or DML invariant failure.
+- Leaves: no fixtures, because the script runs inside `BEGIN`/`ROLLBACK`.
+
+- [ ] **Step 1: Extend the migration test with a failing verifier contract**
+
+Read the verification file and assert it contains:
+
+- `\set ON_ERROR_STOP on`, `BEGIN`, and final `ROLLBACK`;
+- a `run_dml` psql switch that always runs catalog checks and encloses fixtures/role switching/claim behavior in the DML-only branch;
+- `pg_policies`, `has_table_privilege`, `has_function_privilege`, and `pg_trigger` assertions;
+- `pg_class.relrowsecurity = true` for `public.lessons`, absence of `lessons_teacher_own`/`lessons_admin_all`, and presence of normalized manager select/update/delete policies with the NEW-row owner predicate;
+- checks for authenticated select plus denied insert/update/delete;
+- service enqueue, upload, cancel/retry, and worker-state transitions;
+- draft/rejected delete, draft update, approved update/delete rejection, and non-approved cascade;
+- null/source/target transfer rejection, owner/admin success, global-admin success, and service-role maintenance.
+- unchanged original job/usage organization and reservation count after lesson reassignment plus retry.
+
+- [ ] **Step 2: Verify the extended test fails**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+```
+
+Expected: FAIL because the verification script does not exist.
+
+- [ ] **Step 3: Implement a self-contained, rollback-only SQL verifier**
+
+The script must:
+
+1. enable `ON_ERROR_STOP`, default `run_dml` to false when omitted, and start a transaction;
+2. always verify the effective policy/privilege/trigger catalog matrix, including normalized lesson manager policies;
+3. when `run_dml=true`, preflight that the connection can assume both roles and that no queued/running content jobs pre-exist;
+4. only inside that DML branch, create deterministic fixtures and run role-switched behavior tests;
+5. use self-asserting `DO` blocks that raise on false catalog predicates, wrong row counts, wrong persisted values, or unexpected SQLSTATEs;
+6. set local JWT claims/roles exactly when exercising authenticated and service-role behavior;
+7. verify all three mutating RPC ACLs and the existing service-only `insert_generated_lesson_artifact(uuid, uuid, integer, text, integer, jsonb, jsonb, jsonb, uuid, uuid, uuid)` worker RPC;
+8. exercise the DML and trigger matrix listed in Step 1;
+9. close the conditional and roll back after successful verification.
+
+Use this psql framing:
+
+```sql
+\set ON_ERROR_STOP on
+\if :{?run_dml}
+\else
+  \set run_dml false
+\endif
+
+BEGIN;
+\if :run_dml
+\endif
+ROLLBACK;
+```
+
+Place this runnable catalog block immediately after `BEGIN` and before the DML conditional:
+
+```sql
+DO $verify_catalog$
+DECLARE
+  function_name text;
+  job_functions constant text[] := ARRAY[
+    'public.claim_content_jobs(text,integer,integer)',
+    'public.enqueue_content_jobs_with_usage(uuid,uuid,jsonb,jsonb)',
+    'public.create_uploaded_lesson_artifact(uuid,uuid,text,jsonb,jsonb,jsonb)'
+  ];
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'content_jobs'
+      AND policyname IN ('content_jobs_insert_own', 'content_jobs_update_own')
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'content_jobs'
+      AND policyname = 'content_jobs_select_own'
+  ) THEN
+    RAISE EXCEPTION 'content_jobs policy matrix is incorrect';
+  END IF;
+
+  IF NOT has_table_privilege('authenticated', 'public.content_jobs', 'SELECT')
+    OR has_table_privilege('authenticated', 'public.content_jobs', 'INSERT')
+    OR has_table_privilege('authenticated', 'public.content_jobs', 'UPDATE')
+    OR has_table_privilege('authenticated', 'public.content_jobs', 'DELETE')
+    OR has_table_privilege('anon', 'public.content_jobs', 'INSERT')
+    OR has_table_privilege('anon', 'public.content_jobs', 'UPDATE')
+    OR has_table_privilege('anon', 'public.content_jobs', 'DELETE')
+    OR NOT has_table_privilege('service_role', 'public.content_jobs', 'SELECT')
+    OR NOT has_table_privilege('service_role', 'public.content_jobs', 'INSERT')
+    OR NOT has_table_privilege('service_role', 'public.content_jobs', 'UPDATE')
+    OR NOT has_table_privilege('service_role', 'public.content_jobs', 'DELETE') THEN
+    RAISE EXCEPTION 'content_jobs effective privilege matrix is incorrect';
+  END IF;
+
+  FOREACH function_name IN ARRAY job_functions LOOP
+    IF has_function_privilege('authenticated', function_name, 'EXECUTE')
+      OR has_function_privilege('anon', function_name, 'EXECUTE')
+      OR NOT has_function_privilege('service_role', function_name, 'EXECUTE') THEN
+      RAISE EXCEPTION 'job RPC privilege matrix is incorrect for %', function_name;
+    END IF;
+  END LOOP;
+
+  IF has_function_privilege(
+    'authenticated',
+    'public.insert_generated_lesson_artifact(uuid,uuid,integer,text,integer,jsonb,jsonb,jsonb,uuid,uuid,uuid)',
+    'EXECUTE'
+  ) OR NOT has_function_privilege(
+    'service_role',
+    'public.insert_generated_lesson_artifact(uuid,uuid,integer,text,integer,jsonb,jsonb,jsonb,uuid,uuid,uuid)',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'generated-artifact worker RPC privilege matrix is incorrect';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class
+    WHERE oid = 'public.lessons'::regclass AND relrowsecurity
+  ) OR EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'lessons'
+      AND policyname IN ('lessons_teacher_own', 'lessons_admin_all')
+  ) OR (
+    SELECT count(*) FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'lessons'
+      AND policyname IN ('lessons_manager_select', 'lessons_manager_update', 'lessons_manager_delete')
+  ) <> 3 OR NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'lessons'
+      AND policyname = 'lessons_manager_update'
+      AND qual LIKE '%can_manage_lesson%'
+      AND with_check LIKE '%can_assign_lesson_teacher%'
+  ) OR to_regprocedure('public.can_assign_lesson_teacher(uuid)') IS NULL
+    OR NOT has_function_privilege(
+      'authenticated', 'public.can_assign_lesson_teacher(uuid)', 'EXECUTE'
+    ) THEN
+    RAISE EXCEPTION 'lesson manager RLS matrix is incorrect';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.lesson_artifacts'::regclass
+      AND tgname = 'lesson_artifacts_approved_immutable'
+      AND tgenabled = 'O'
+      AND tgfoid = 'public.prevent_approved_artifact_mutation()'::regprocedure
+  ) OR NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.lessons'::regclass
+      AND tgname = 'lessons_organization_reassignment_guard'
+      AND tgenabled = 'O'
+      AND tgfoid = 'public.prevent_invalid_lesson_organization_reassignment()'::regprocedure
+  ) THEN
+    RAISE EXCEPTION 'hardening trigger attachment is incorrect';
+  END IF;
+END;
+$verify_catalog$;
+```
+
+The DML preflight must fail before fixtures if this query returns any row:
+
+```sql
+SELECT id FROM public.content_jobs
+WHERE status IN ('queued', 'running')
+LIMIT 1;
+```
+
+Implement that as a `DO` assertion, not a visual/manual check.
+
+Use stable fixture variables so every assertion identifies the same rows:
+
+```sql
+\set teacher_user_id  '10000000-0000-4000-8000-000000000001'
+\set admin_user_id    '10000000-0000-4000-8000-000000000002'
+\set other_teacher_user_id '10000000-0000-4000-8000-000000000003'
+\set teacher_id       '20000000-0000-4000-8000-000000000001'
+\set other_teacher_id '20000000-0000-4000-8000-000000000002'
+\set source_org_id    '30000000-0000-4000-8000-000000000001'
+\set target_org_id    '30000000-0000-4000-8000-000000000002'
+\set lesson_id        '40000000-0000-4000-8000-000000000001'
+\set objective_id     '50000000-0000-4000-8000-000000000001'
+\set job_id           '60000000-0000-4000-8000-000000000001'
+\set upload_job_id    '60000000-0000-4000-8000-000000000002'
+\set batch_id         '70000000-0000-4000-8000-000000000001'
+\set upload_batch_id  '70000000-0000-4000-8000-000000000002'
+\set draft_artifact   '80000000-0000-4000-8000-000000000001'
+\set rejected_artifact '80000000-0000-4000-8000-000000000002'
+\set approved_artifact '80000000-0000-4000-8000-000000000003'
+\set upload_artifact  '80000000-0000-4000-8000-000000000004'
+\set upload_asset     '90000000-0000-4000-8000-000000000001'
+```
+
+Insert only current-schema columns, using these exact fixture shapes:
+
+- `public.users(id, email, name, role)`: the owning teacher, a second teacher, and one global admin;
+- `public.teachers(id, user_id)`: both teacher profiles;
+- `public.organizations(id, name, owner_id)`: source and target organizations;
+- `public.organization_members(organization_id, user_id, role, is_active)`: normalize the trigger-created teacher rows to the role/state needed by each test, restoring active owner/admin rows between rejection cases;
+- `public.lessons(id, title, subject, gradelevel, objectives, content, teacher_id, organization_id)`: one teacher-owned source-organization lesson;
+- `public.lesson_objectives(id, lesson_id, text, position, revision)`: the active objective;
+- `public.lesson_artifacts(id, lesson_id, objective_id, series_id, version, objective_revision, kind, status, position, payload, source, created_by)`: separate draft, rejected, approved, and cascade fixtures with unique series IDs.
+
+Use `ON CONFLICT` only where setup triggers can legitimately precreate a membership. Any unexpected pre-existing deterministic ID should fail the disposable-environment gate rather than silently reuse unrelated data.
+
+After inserting fixtures, expose those IDs to dollar-quoted assertion blocks:
+
+```sql
+CREATE TEMP TABLE verification_ids (
+  teacher_user_id uuid,
+  admin_user_id uuid,
+  other_teacher_user_id uuid,
+  teacher_id uuid,
+  other_teacher_id uuid,
+  source_org_id uuid,
+  target_org_id uuid,
+  lesson_id uuid,
+  objective_id uuid,
+  job_id uuid,
+  draft_artifact uuid,
+  rejected_artifact uuid,
+  approved_artifact uuid
+) ON COMMIT DROP;
+
+INSERT INTO verification_ids VALUES (
+  :'teacher_user_id', :'admin_user_id', :'other_teacher_user_id',
+  :'teacher_id', :'other_teacher_id',
+  :'source_org_id', :'target_org_id', :'lesson_id', :'objective_id', :'job_id',
+  :'draft_artifact', :'rejected_artifact', :'approved_artifact'
+);
+
+GRANT SELECT ON verification_ids TO authenticated, service_role;
+```
+
+Preflight the connection before inserts:
+
+```sql
+DO $$
+BEGIN
+  IF NOT pg_has_role(current_user, 'authenticated', 'MEMBER')
+    OR NOT pg_has_role(current_user, 'service_role', 'MEMBER') THEN
+    RAISE EXCEPTION 'Verification requires a direct migration-owner connection that can assume authenticated and service_role';
+  END IF;
+END;
+$$;
+SET LOCAL ROLE authenticated;
+RESET ROLE;
+SET LOCAL ROLE service_role;
+RESET ROLE;
+```
+
+For every authenticated block, set both scalar and JSON Supabase claim GUCs before assuming the role; repeat with `service_role` for trusted RPC blocks:
+
+```sql
+SELECT set_config('request.jwt.claim.sub', :'teacher_user_id', true);
+SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+SELECT set_config(
+  'request.jwt.claims',
+  jsonb_build_object('sub', :'teacher_user_id', 'role', 'authenticated')::text,
+  true
+);
+SET LOCAL ROLE authenticated;
+SELECT id FROM public.content_jobs
+WHERE id = :'job_id' AND requested_by = :'teacher_user_id';
+RESET ROLE;
+```
+
+For service RPC blocks, replace the role in both claim GUCs and assume `service_role`:
+
+```sql
+SELECT set_config('request.jwt.claim.sub', :'teacher_user_id', true);
+SELECT set_config('request.jwt.claim.role', 'service_role', true);
+SELECT set_config(
+  'request.jwt.claims',
+  jsonb_build_object('sub', :'teacher_user_id', 'role', 'service_role')::text,
+  true
+);
+SET LOCAL ROLE service_role;
+SELECT auth.role();
+RESET ROLE;
+```
+
+Because psql does not substitute `:variables` inside dollar-quoted `DO` bodies, persist fixture IDs in a `pg_temp.verification_ids` row before exception blocks. PL/pgSQL blocks must select IDs from that temp row rather than embedding psql variables inside `$$ ... $$`. The explicit grant above is required because changing roles does not inherit the migration owner's temp-table privileges.
+
+Each expected failure belongs in a nested PL/pgSQL exception block. ACL and organization-guard failures must match SQLSTATE `42501` and the guard's stable message. Approved artifact update/delete must instead match SQLSTATE `P0001` and `Approved lesson artifacts are immutable; create a new version`. If the statement unexpectedly succeeds, or a different code/message is raised, re-raise and fail the script.
+
+Use the same fail-closed shape for every expected error:
+
+```sql
+DO $$
+DECLARE
+  ids pg_temp.verification_ids%ROWTYPE;
+  raised_message text;
+BEGIN
+  SELECT * INTO STRICT ids FROM pg_temp.verification_ids;
+  BEGIN
+    UPDATE public.lessons SET organization_id = NULL WHERE id = ids.lesson_id;
+    RAISE EXCEPTION 'Expected organization clear to fail' USING ERRCODE = 'ZX001';
+  EXCEPTION WHEN SQLSTATE '42501' THEN
+    GET STACKED DIAGNOSTICS raised_message = MESSAGE_TEXT;
+    IF raised_message <> 'Lesson organization cannot be cleared' THEN
+      RAISE EXCEPTION 'Wrong organization-clear error: %', raised_message;
+    END IF;
+  END;
+END;
+$$;
+```
+
+Implement this complete behavior matrix; do not replace a row with a source-string assertion:
+
+| Actor/setup | Operation | Required assertion |
+|---|---|---|
+| authenticated teacher, own job | `SELECT` | fixture job returned |
+| authenticated teacher | direct job `INSERT`, `UPDATE`, `DELETE` | each raises `42501`; fixture unchanged |
+| service role | enqueue with usage | one queued job and one source-org usage row |
+| service role, isolated queue | `claim_content_jobs` | only fixture job becomes running with lease/attempt increment |
+| service role | cancel queued fixture | one row becomes cancelled |
+| service role | retry failed/cancelled fixture | one row returns to queued without new usage |
+| service role | worker success transition | one owned running row becomes succeeded and releases lease |
+| service role | upload RPC | returned and persisted asset/artifact/job IDs match fixtures |
+| service role, draft/rejected | update/delete | exact row count one and persisted/absent state matches |
+| service role, approved | update/delete | `P0001` plus exact immutability message; row unchanged |
+| service role, non-approved parent | cascade delete | child artifact no longer exists |
+| teacher active owner/admin in source and target | lesson reassignment | one row updated to target |
+| teacher missing/inactive/member in source | lesson reassignment | `42501` plus current-organization message; row unchanged |
+| teacher missing/inactive/member in target | lesson reassignment | `42501` plus target-organization message; row unchanged |
+| teacher | explicit organization `NULL` | `42501` plus clear message; row unchanged |
+| teacher | change `teacher_id` to another teacher | RLS rejects; owner remains unchanged |
+| global admin user | source-to-target reassignment | succeeds without memberships |
+| global admin user | intentional `teacher_id` change | succeeds through NEW-row owner predicate |
+| service role | reassignment or null maintenance | succeeds as explicit maintenance bypass |
+
+Execute the DML rows in this order so each precondition is deterministic: isolation/role preflight; fixture inserts; service enqueue with usage; authenticated read/write denial; service claim; cancel/retry/worker transitions; upload RPC; artifact update/delete/cascade; teacher/admin/service organization cases; original-org quota assertions; `RESET ROLE`; `\endif`; `ROLLBACK`.
+
+Use exact catalog predicates such as:
+
+```sql
+IF NOT has_table_privilege('authenticated', 'public.content_jobs', 'SELECT')
+  OR has_table_privilege('authenticated', 'public.content_jobs', 'INSERT')
+  OR has_table_privilege('authenticated', 'public.content_jobs', 'UPDATE')
+  OR has_table_privilege('authenticated', 'public.content_jobs', 'DELETE') THEN
+  RAISE EXCEPTION 'content_jobs authenticated privilege matrix is incorrect';
+END IF;
+
+IF NOT has_function_privilege(
+  'service_role',
+  'public.enqueue_content_jobs_with_usage(uuid,uuid,jsonb,jsonb)',
+  'EXECUTE'
+) THEN
+  RAISE EXCEPTION 'service_role cannot execute enqueue_content_jobs_with_usage';
+END IF;
+```
+
+Authorization failures for ACL and organization-guard cases must assert SQLSTATE `42501`; any other error fails the verifier. For successful artifact behavior, capture `ROW_COUNT` and query persisted state: draft/rejected deletes each affect one row and leave no row, draft update affects one row and persists its new payload, and the non-approved parent cascade removes its child artifact. This prevents an unrelated FK/RLS error from satisfying the test.
+
+For quota attribution, enqueue `job_id` in `source_org_id` with one usage item `{ "category": "quiz_generation", "quantity": 1, "referenceId": "verify:quota" }`. Record the job organization and matching ledger count, reassign the lesson to `target_org_id` through the service-role maintenance path, and perform the existing retry transition on that job. Assert afterward that:
+
+- the job still owns `source_org_id`;
+- the usage row still owns `source_org_id`;
+- exactly one `verify:quota` usage reservation exists;
+- no matching target-organization reservation was created.
+
+Use this exact enqueue shape so the verifier exercises the real quota RPC rather than a direct fixture insert:
+
+```sql
+SELECT public.enqueue_content_jobs_with_usage(
+  :'source_org_id'::uuid,
+  :'teacher_user_id'::uuid,
+  jsonb_build_array(jsonb_build_object(
+    'id', :'job_id',
+    'batch_id', :'batch_id',
+    'lesson_id', :'lesson_id',
+    'objective_id', :'objective_id',
+    'requested_by', :'teacher_user_id',
+    'job_type', 'generate_structured_quiz',
+    'idempotency_key', 'verify:quota',
+    'input', '{}'::jsonb
+  )),
+  jsonb_build_array(jsonb_build_object(
+    'category', 'quiz_generation',
+    'quantity', 1,
+    'referenceId', 'verify:quota'
+  ))
+);
+```
+
+The upload-RPC case must use the complete contract and materialize its return value for assertions:
+
+```sql
+CREATE TEMP TABLE verification_upload_result (payload jsonb) ON COMMIT DROP;
+GRANT INSERT, SELECT ON verification_upload_result TO service_role;
+
+-- Run this INSERT only after setting service-role claims and SET LOCAL ROLE service_role.
+INSERT INTO pg_temp.verification_upload_result (payload)
+SELECT public.create_uploaded_lesson_artifact(
+  :'source_org_id'::uuid,
+  :'teacher_user_id'::uuid,
+  'verify:upload',
+  jsonb_build_object(
+    'id', :'upload_asset',
+    'lesson_id', :'lesson_id',
+    'objective_id', :'objective_id',
+    'asset_type', 'uploaded_media',
+    'storage_bucket', 'lesson-assets',
+    'storage_path', 'verification/' || :'upload_asset',
+    'mime_type', 'image/png',
+    'byte_size', 1,
+    'checksum_sha256', repeat('a', 64),
+    'original_filename', 'verification.png',
+    'alt_text', 'Verification image',
+    'caption', '',
+    'processing_status', 'ready'
+  ),
+  jsonb_build_object(
+    'id', :'upload_artifact',
+    'lesson_id', :'lesson_id',
+    'objective_id', :'objective_id',
+    'objective_revision', 1,
+    'kind', 'uploaded_media',
+    'position', 9,
+    'payload', jsonb_build_object('assetId', :'upload_asset')
+  ),
+  jsonb_build_object(
+    'id', :'upload_job_id',
+    'batch_id', :'upload_batch_id',
+    'lesson_id', :'lesson_id',
+    'objective_id', :'objective_id',
+    'job_type', 'extract_media',
+    'idempotency_key', 'verify:upload-job',
+    'input', '{}'::jsonb
+  )
+) AS payload;
+```
+
+After `RESET ROLE`, assert `payload #>> '{asset,id}'`, `payload #>> '{artifact,id}'`, and `payload #>> '{job,id}'` equal their deterministic IDs, and confirm all three rows exist before continuing. Creating the temp table as the migration owner before role switching avoids cross-role ownership failures.
+
+- [ ] **Step 4: Verify the checked-in contract**
+
+Run:
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+git diff --check
+```
+
+Expected: PASS. This source contract only guards that the intended matrix remains checked in; PostgreSQL execution in Step 6 is the sole proof that the verifier and migration behave correctly.
+
+- [ ] **Step 5: Commit Task 5**
+
+```powershell
+git add supabase/verification/0035_harden_lesson_artifact_writes.sql src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+git commit -m "test(db): add hardening verifier"
+```
+
+- [ ] **Step 6: Run the production-rollout database gate when direct environments are available**
+
+For the full DML matrix, use direct migration-owner connections to isolated, empty disposable environments. Expect exit code `0`, no assertion raises, and the transaction rolls back. Run against both:
+
+- a clean environment provisioned from the operator's canonical `0034` schema baseline, after applying `0035`;
+- an isolated upgrade clone already at `0034`, after applying only `0035`.
+
+Do not call the first environment a raw full-chain replay; the known `0021` typo makes that a separate migration-history repair.
+
+Use the two operator-provided direct URLs explicitly:
+
+```powershell
+$env:DATABASE_URL = $env:BASELINE_DATABASE_URL
+psql $env:DATABASE_URL -X -v ON_ERROR_STOP=1 -v run_dml=true -f 'supabase\verification\0035_harden_lesson_artifact_writes.sql'
+$env:DATABASE_URL = $env:UPGRADE_DATABASE_URL
+psql $env:DATABASE_URL -X -v ON_ERROR_STOP=1 -v run_dml=true -f 'supabase\verification\0035_harden_lesson_artifact_writes.sql'
+```
+
+The repository has no `supabase/config.toml`, migration-runner command, canonical baseline, or disposable database harness. Therefore the operator must provide `BASELINE_DATABASE_URL`, `UPGRADE_DATABASE_URL`, and the canonical `0034` baseline externally. Record both platform migration results and both verifier exit codes in rollout evidence; do not describe them as repo-automated CI.
+
+After the migration reaches a shared staging or production target, run catalog-only mode; it must not create fixtures or call `claim_content_jobs`:
+
+```powershell
+psql $env:DATABASE_URL -X -v ON_ERROR_STOP=1 -v run_dml=false -f 'supabase\verification\0035_harden_lesson_artifact_writes.sql'
+```
+
+This is a production-rollout gate, not a merge blocker.
+
+---
+
+### Task 6: Run project verification and stage the rollout safely
+
+**Files:**
+- Verify only; no new production files expected.
+
+- [ ] **Step 1: Run all focused regression tests together**
+
+```powershell
+pnpm exec vitest run src/lib/lesson-artifacts/__tests__/lesson-update.test.ts src/lib/lesson-artifacts/__tests__/lesson-update-route.test.ts src/lib/lesson-artifacts/__tests__/lesson-route-contract.test.ts src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+```
+
+Expected: all focused files pass with zero failed tests.
+
+- [ ] **Step 2: Run repository gates**
+
+```powershell
+pnpm test
+pnpm typecheck
+pnpm lint
+git diff --check
+```
+
+Expected: all commands exit `0`; no test, type, lint, or whitespace errors.
+
+- [ ] **Step 3: Review the final diff against invariants**
+
+Confirm:
+
+- only migration `0035` changes database history;
+- no browser/user-scoped path writes `content_jobs`;
+- PUT omission and edit-form payloads do not own an organization field;
+- trusted membership reads and authenticated lesson writes use visibly different clients;
+- source and target roles are both enforced in TypeScript and SQL;
+- draft/rejected deletion returns `OLD`, while approved immutability is unchanged;
+- no code reassigns already-reserved jobs or usage rows.
+
+- [ ] **Step 4: Deploy in the required order**
+
+1. Apply migration `0035` to the isolated upgrade clone and require the full `run_dml=true` verifier to exit `0`.
+2. Apply migration `0035` to the shared target.
+3. Run `run_dml=false` catalog-only verification on the shared target and require exit `0`.
+4. Confirm bundle generation, regeneration/retry, upload extraction, cancellation, and worker progression still succeed through service-role paths.
+5. Deploy the application route/form changes.
+6. Edit an existing lesson without choosing an organization and verify its `organization_id` remains unchanged.
+7. Exercise one authorized reassignment and one insufficient-role reassignment; expect success and `403`, respectively.
+
+- [ ] **Step 5: Monitor and recover forward-only**
+
+Monitor permission errors, lesson PUT `400/403/500` rates, queued jobs that stop progressing, and worker failures. If a defect appears, roll back the application bundle if useful, but repair database behavior with a new forward migration. Never restore authenticated job writes, null organization detachment, or `RETURN NEW` for artifact deletes.

--- a/docs/superpowers/specs/2026-07-11-pr-13-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-11-pr-13-review-fixes-design.md
@@ -28,19 +28,22 @@ The edit form will omit `organizationId` because it does not expose an organizat
 
 The route-level check provides clear HTTP errors, while a `BEFORE UPDATE OF organization_id` database trigger enforces the same rule atomically for direct authenticated updates. The trigger also verifies `can_manage_lesson(OLD.id)`. `service_role` is exempt so trusted administrative maintenance remains possible. Reassignment affects future jobs only; already-reserved jobs retain their original organization and usage ledger.
 
+Because the final update intentionally uses the authenticated client, the migration will also normalize lesson manager RLS and make lesson updates column-scoped. It will clear both table-level and every existing column-level authenticated `UPDATE` grant before granting the exact allowlist: `title`, `subject`, `gradelevel`, `objectives`, `content`, `organization_id`, and `updated_at`. Legacy `teacher`, normalized `teacher_id`, `current_publication_id`, and every other system field remain service-role-only. Authenticated global administrators receive no protected-column exception; intentional ownership or publication-pointer maintenance must use a trusted service path, not direct authenticated SQL.
+
 ### Artifact deletion uses the operation-appropriate trigger row
 
 The forward migration will replace `prevent_approved_artifact_mutation()` in place. Approved artifacts will remain immutable. For other rows, the trigger returns `OLD` during `DELETE` and `NEW` during `UPDATE`, allowing draft/rejected artifact deletion and normal cascades while retaining approved-row protection.
 
 ## Migration Strategy
 
-Create `supabase/migrations/0035_harden_lesson_artifact_writes.sql`. Do not edit migrations `0033` or `0034`, because they have already been applied. The migration will be idempotent where PostgreSQL supports it:
+Create `supabase/migrations/0035_harden_lesson_artifact_writes.sql`. Do not edit migrations `0033` or `0034`, because they have already been applied. Wrap the complete migration in an explicit transaction so any failure rolls back every ACL, policy, function, and trigger change. The migration will be idempotent where PostgreSQL supports it:
 
 1. drop `content_jobs_insert_own` and `content_jobs_update_own` if present;
 2. revoke all `content_jobs` privileges from `PUBLIC`, `anon`, and `authenticated`, grant `SELECT` to `authenticated`, and explicitly retain trusted `service_role` writes;
 3. reassert service-role-only execution grants for job-mutating RPCs;
-4. replace the approved-artifact trigger function with explicit `RETURN OLD` for `DELETE` and `RETURN NEW` for `UPDATE`;
-5. add the lesson-organization guard trigger described above.
+4. enable lesson RLS, remove every existing browser-applicable write policy regardless of name, recreate only normalized manager select/update/delete policies, revoke table-level and all current column-level lesson updates from browser roles, and grant authenticated only the exact editable-column allowlist;
+5. add the lesson-organization guard trigger described above;
+6. replace the approved-artifact trigger function with explicit `RETURN OLD` for `DELETE` and `RETURN NEW` for `UPDATE`.
 
 The migration will drop and recreate both triggers idempotently so environments with schema drift end in the same state.
 
@@ -54,6 +57,7 @@ The lesson form will construct a shared payload for title, subject, grade, objec
 
 - Malformed or `null` organization reassignment returns `400`.
 - Reassignment without the required source or target role returns `403`.
+- A database `42501` maps to the transfer-specific `403` only when the request attempted a real organization change and the error message matches a known organization-guard rejection. Other `42501` errors retain generic server-error handling.
 - A membership-query failure returns `500`; no lesson update is attempted.
 - Other database errors retain the route's existing server-error behavior.
 - Quota-enforced enqueue RPCs remain the only path for new generation jobs.
@@ -64,23 +68,23 @@ The lesson form will construct a shared payload for title, subject, grade, objec
 Add regression coverage before production changes. Source-substring assertions may supplement these tests but cannot be the sole proof of behavior.
 
 1. lesson update mapper: use `Object.hasOwn` to prove omission excludes `organization_id`, while an explicit UUID includes it;
-2. route behavior: omission and same-ID updates skip membership lookup; authorized reassignment succeeds; malformed/null, inactive, missing, or insufficient-role memberships fail before update; global-admin behavior is explicit;
+2. route behavior: omission and same-ID updates skip membership lookup; authorized reassignment succeeds; malformed/null, inactive, missing, or insufficient-role memberships fail before update; global-admin behavior is explicit; a non-transfer `42501` is not mislabeled as an organization denial;
 3. form payload behavior: creation includes `organizationId`, editing omits it;
-4. migration catalog checks: write policies are absent from `pg_policies`, authenticated effective write privileges are false through `has_table_privilege`, authenticated `SELECT` remains true, service-role writes remain true, and mutating RPC execute privileges are service-role-only;
+4. migration catalog checks: content-job write policies are absent from `pg_policies`, authenticated content-job write privileges are false, authenticated `SELECT` remains true, service-role writes remain true, mutating RPC execute privileges are service-role-only, lesson RLS is enabled, legacy lesson manager policies are absent, and authenticated lesson UPDATE privileges match the editable-column allowlist exactly;
 5. content-job behavior: authenticated own-row `INSERT`, `UPDATE`, and `DELETE` fail, authorized `SELECT` succeeds, and service-role enqueue/cancel/retry/worker/upload paths still succeed;
 6. artifact behavior: draft/rejected deletes remove rows, draft updates persist, approved update/delete operations raise, and a non-approved parent cascade completes;
-7. migration paths: both a fresh migration chain and an upgrade from `0034` to `0035` reach the same privileges, policies, functions, and triggers;
+7. migration paths: an isolated database provisioned from the operator's canonical `0034` schema baseline and an isolated `0034` upgrade clone both reach the same privileges, policies, functions, and triggers after `0035`; raw historical replay is a separate migration-governance issue because migration `0021` currently indexes nonexistent `teacherid` columns;
 8. project gates: targeted tests, full Vitest, `tsc --noEmit`, targeted ESLint, and `git diff --check` all complete with zero failures or errors.
 
-The repository does not currently include a disposable Supabase test harness. CI will cover pure helpers, route orchestration, form payloads, and migration contracts. A checked-in SQL verification script will cover catalog and DML behavior on a disposable or staging database after migration application. Its expected results are a production-rollout gate; migration contract tests remain the merge gate until a disposable database is added to CI.
+The repository does not currently include a disposable Supabase test harness. CI will cover pure helpers, route orchestration, form payloads, and migration source contracts. Before merge, two operator-provided isolated databases still at `0034`—an empty schema-only canonical baseline and a representative upgrade-state clone—must independently apply `0035` and pass the checked-in catalog and rollback-only DML verifier. If either environment is unavailable, database verification is blocked and the change is not merge-ready. Full DML verification never runs on shared staging or production because `claim_content_jobs` claims globally; shared targets run catalog-only verification.
 
 ## Rollout and Recovery
 
-Apply migration `0035` before deploying the application changes. This order is backward compatible because all legitimate job writers already use `service_role`; any permission failure before the app deploy indicates an undocumented client write path that must be moved behind an API rather than re-enabled.
+Deploy the omission-aware lesson route and form together before applying migration `0035`. The current route and form both materialize `organization_id = null`, so migration-first deployment would make ordinary lesson edits fail as soon as the null-rejecting trigger is active. During this short compatibility window, ordinary edits are safe; explicit organization reassignment is not considered released until `0035` is applied.
 
-After migration, verify the database acceptance matrix and monitor for permission errors, rising failed API requests, or queued jobs that stop progressing. Then deploy the route and form changes and exercise omission plus authorized reassignment.
+Immediately apply `0035`, run catalog-only verification on the shared target, verify service-role bundle generation/regeneration/upload/cancellation/worker paths, then exercise omission plus authorized and denied reassignment. Monitor permission errors, lesson PUT status rates, and queued jobs that stop progressing.
 
-Rollback is forward-only. Do not restore authenticated job writes or the broken delete-trigger return. If an issue appears, ship a corrective migration while retaining the access restrictions; rolling back only the application bundle must not restore organization-clearing behavior.
+Before `0035`, the compatibility application deploy may be rolled back normally. After `0035`, do not roll back to the old route/form because that recreates an edit outage; recovery is forward-only with a corrected application or migration. Never restore authenticated job writes, broad lesson-column updates, null organization detachment, or the broken delete-trigger return.
 
 ## Non-Goals
 

--- a/docs/superpowers/specs/2026-07-11-pr-13-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-11-pr-13-review-fixes-design.md
@@ -1,0 +1,69 @@
+# PR 13 Review Fixes Design
+
+## Goal
+
+Close the three unresolved Codex findings from PR #13 without rewriting migrations that have already been applied. The changes must prevent unmetered content-job execution, preserve lesson organization ownership during ordinary edits, and restore valid deletion behavior for non-approved artifacts.
+
+## Decisions
+
+### Content jobs are read-only to authenticated database clients
+
+Authenticated users may continue selecting jobs allowed by the existing ownership policy, but they may not insert, update, or delete `content_jobs` directly. A new forward migration will drop the authenticated insert and update policies and revoke write privileges from `anon` and `authenticated`.
+
+All legitimate writes remain server-controlled. Bundle generation and regeneration enqueue through the service-role-only `enqueue_content_jobs_with_usage` RPC, upload extraction uses the service-role-only upload RPC, and cancellation/retry/worker transitions use the server-side service-role client. This keeps quota reservation and job creation atomic.
+
+### Lesson organization changes are explicit and validated
+
+An update that omits `organizationId` will not include `organization_id` in the database update, preserving the current owner. An explicit UUID or `null` remains supported for compatibility, but the route will validate it before mutation:
+
+- a UUID must belong to an active organization membership for the authenticated user;
+- `null` explicitly clears ownership;
+- omission preserves ownership.
+
+The edit form will omit `organizationId` because it does not expose an organization selector in edit mode. Creation will continue sending the selected organization.
+
+### Artifact deletion uses the operation-appropriate trigger row
+
+The forward migration will replace `prevent_approved_artifact_mutation()` in place. Approved artifacts will remain immutable. For other rows, the trigger returns `OLD` during `DELETE` and `NEW` during `UPDATE`, allowing draft/rejected artifact deletion and normal cascades while retaining approved-row protection.
+
+## Migration Strategy
+
+Create `supabase/migrations/0035_harden_lesson_artifact_writes.sql`. Do not edit migrations `0033` or `0034`, because they have already been applied. The migration will be idempotent where PostgreSQL supports it:
+
+1. drop `content_jobs_insert_own` and `content_jobs_update_own` if present;
+2. revoke `INSERT`, `UPDATE`, and `DELETE` on `content_jobs` from `anon` and `authenticated`;
+3. replace the approved-artifact trigger function with operation-aware return behavior.
+
+The existing trigger remains attached to the replaced function and does not need recreation.
+
+## Application Changes
+
+Extract a pure lesson-update mapper that converts the validated API payload to database column names and conditionally includes `organization_id`. The lesson PUT route will use that mapper and perform active-membership validation only when `organizationId` is explicitly supplied.
+
+The lesson form will construct a shared payload for title, subject, grade, objectives, and content, then add `organizationId` only for lesson creation.
+
+## Error Handling
+
+- Explicit reassignment to an organization without active membership returns `403`.
+- Database or membership-query errors retain the route's existing server-error behavior.
+- Quota-enforced enqueue RPCs remain the only path for new generation jobs.
+- Approved artifact updates and deletions continue raising the existing immutability error.
+
+## Testing
+
+Add regression coverage before production changes:
+
+1. migration contract: authenticated write policies are removed and write privileges revoked;
+2. migration contract: the delete trigger returns `OLD` while updates return `NEW`;
+3. lesson update mapper: omission preserves the organization column, UUID includes it, and explicit `null` clears it;
+4. route/form contract: explicit organization changes require membership validation and edit payloads omit `organizationId`;
+5. full Vitest suite, TypeScript, targeted ESLint, and `git diff --check`.
+
+Database-level behavior will also be checked when the migration is applied: authenticated direct job writes must fail, service-role RPC enqueue must succeed, draft deletion must succeed, and approved deletion must fail.
+
+## Non-Goals
+
+- Changing quota limits or categories.
+- Allowing browser clients to mutate content-job state.
+- Rewriting applied migration history.
+- Changing approved-artifact immutability or publication immutability.

--- a/docs/superpowers/specs/2026-07-11-pr-13-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-11-pr-13-review-fixes-design.md
@@ -8,19 +8,25 @@ Close the three unresolved Codex findings from PR #13 without rewriting migratio
 
 ### Content jobs are read-only to authenticated database clients
 
-Authenticated users may continue selecting jobs allowed by the existing ownership policy, but they may not insert, update, or delete `content_jobs` directly. A new forward migration will drop the authenticated insert and update policies and revoke write privileges from `anon` and `authenticated`.
+Authenticated users may continue selecting jobs allowed by the existing ownership policy, but they may not insert, update, or delete `content_jobs` directly. A new forward migration will drop the authenticated insert and update policies, revoke all table privileges from `PUBLIC`, `anon`, and `authenticated`, then grant only `SELECT` back to `authenticated`. Direct `service_role` access remains available for trusted server operations.
 
 All legitimate writes remain server-controlled. Bundle generation and regeneration enqueue through the service-role-only `enqueue_content_jobs_with_usage` RPC, upload extraction uses the service-role-only upload RPC, and cancellation/retry/worker transitions use the server-side service-role client. This keeps quota reservation and job creation atomic.
 
+The migration will reassert that content-job-mutating RPCs are executable only by `service_role`. Existing quota semantics stay unchanged: a reservation belongs to the organization recorded when the job is enqueued, and retries of that reserved job do not reserve quota again.
+
 ### Lesson organization changes are explicit and validated
 
-An update that omits `organizationId` will not include `organization_id` in the database update, preserving the current owner. An explicit UUID or `null` remains supported for compatibility, but the route will validate it before mutation:
+An update that omits `organizationId` will not include `organization_id` in the database update, preserving the current owner. Explicit reassignment accepts a UUID only; `null` is rejected so an organization-owned lesson cannot be detached to bypass future quota attribution.
 
-- a UUID must belong to an active organization membership for the authenticated user;
-- `null` explicitly clears ownership;
-- omission preserves ownership.
+- omission preserves ownership and performs no membership lookup;
+- supplying the existing UUID is a no-op and preserves ownership;
+- a different UUID requires the teacher to be an active `owner` or `admin` in both the current organization, when present, and the target organization;
+- a global administrator may reassign without organization membership;
+- malformed UUIDs and `null` return `400` without mutating the lesson.
 
 The edit form will omit `organizationId` because it does not expose an organization selector in edit mode. Creation will continue sending the selected organization.
+
+The route-level check provides clear HTTP errors, while a `BEFORE UPDATE OF organization_id` database trigger enforces the same rule atomically for direct authenticated updates. The trigger also verifies `can_manage_lesson(OLD.id)`. `service_role` is exempt so trusted administrative maintenance remains possible. Reassignment affects future jobs only; already-reserved jobs retain their original organization and usage ledger.
 
 ### Artifact deletion uses the operation-appropriate trigger row
 
@@ -31,35 +37,50 @@ The forward migration will replace `prevent_approved_artifact_mutation()` in pla
 Create `supabase/migrations/0035_harden_lesson_artifact_writes.sql`. Do not edit migrations `0033` or `0034`, because they have already been applied. The migration will be idempotent where PostgreSQL supports it:
 
 1. drop `content_jobs_insert_own` and `content_jobs_update_own` if present;
-2. revoke `INSERT`, `UPDATE`, and `DELETE` on `content_jobs` from `anon` and `authenticated`;
-3. replace the approved-artifact trigger function with operation-aware return behavior.
+2. revoke all `content_jobs` privileges from `PUBLIC`, `anon`, and `authenticated`, grant `SELECT` to `authenticated`, and explicitly retain trusted `service_role` writes;
+3. reassert service-role-only execution grants for job-mutating RPCs;
+4. replace the approved-artifact trigger function with explicit `RETURN OLD` for `DELETE` and `RETURN NEW` for `UPDATE`;
+5. add the lesson-organization guard trigger described above.
 
-The existing trigger remains attached to the replaced function and does not need recreation.
+The migration will drop and recreate both triggers idempotently so environments with schema drift end in the same state.
 
 ## Application Changes
 
-Extract a pure lesson-update mapper that converts the validated API payload to database column names and conditionally includes `organization_id`. The lesson PUT route will use that mapper and perform active-membership validation only when `organizationId` is explicitly supplied.
+Extract a pure lesson-update mapper that converts the validated API payload to database column names and conditionally includes `organization_id`. The lesson PUT route will use that mapper, compare an explicit organization with the persisted value, and query source/target memberships only for a real reassignment. Membership reads use the trusted server client after the route has authenticated and authorized the lesson manager. The final update continues through the authenticated user client so the database trigger evaluates the real actor and remains the atomic enforcement boundary.
 
 The lesson form will construct a shared payload for title, subject, grade, objectives, and content, then add `organizationId` only for lesson creation.
 
 ## Error Handling
 
-- Explicit reassignment to an organization without active membership returns `403`.
-- Database or membership-query errors retain the route's existing server-error behavior.
+- Malformed or `null` organization reassignment returns `400`.
+- Reassignment without the required source or target role returns `403`.
+- A membership-query failure returns `500`; no lesson update is attempted.
+- Other database errors retain the route's existing server-error behavior.
 - Quota-enforced enqueue RPCs remain the only path for new generation jobs.
 - Approved artifact updates and deletions continue raising the existing immutability error.
 
 ## Testing
 
-Add regression coverage before production changes:
+Add regression coverage before production changes. Source-substring assertions may supplement these tests but cannot be the sole proof of behavior.
 
-1. migration contract: authenticated write policies are removed and write privileges revoked;
-2. migration contract: the delete trigger returns `OLD` while updates return `NEW`;
-3. lesson update mapper: omission preserves the organization column, UUID includes it, and explicit `null` clears it;
-4. route/form contract: explicit organization changes require membership validation and edit payloads omit `organizationId`;
-5. full Vitest suite, TypeScript, targeted ESLint, and `git diff --check`.
+1. lesson update mapper: use `Object.hasOwn` to prove omission excludes `organization_id`, while an explicit UUID includes it;
+2. route behavior: omission and same-ID updates skip membership lookup; authorized reassignment succeeds; malformed/null, inactive, missing, or insufficient-role memberships fail before update; global-admin behavior is explicit;
+3. form payload behavior: creation includes `organizationId`, editing omits it;
+4. migration catalog checks: write policies are absent from `pg_policies`, authenticated effective write privileges are false through `has_table_privilege`, authenticated `SELECT` remains true, service-role writes remain true, and mutating RPC execute privileges are service-role-only;
+5. content-job behavior: authenticated own-row `INSERT`, `UPDATE`, and `DELETE` fail, authorized `SELECT` succeeds, and service-role enqueue/cancel/retry/worker/upload paths still succeed;
+6. artifact behavior: draft/rejected deletes remove rows, draft updates persist, approved update/delete operations raise, and a non-approved parent cascade completes;
+7. migration paths: both a fresh migration chain and an upgrade from `0034` to `0035` reach the same privileges, policies, functions, and triggers;
+8. project gates: targeted tests, full Vitest, `tsc --noEmit`, targeted ESLint, and `git diff --check` all complete with zero failures or errors.
 
-Database-level behavior will also be checked when the migration is applied: authenticated direct job writes must fail, service-role RPC enqueue must succeed, draft deletion must succeed, and approved deletion must fail.
+The repository does not currently include a disposable Supabase test harness. CI will cover pure helpers, route orchestration, form payloads, and migration contracts. A checked-in SQL verification script will cover catalog and DML behavior on a disposable or staging database after migration application. Its expected results are a production-rollout gate; migration contract tests remain the merge gate until a disposable database is added to CI.
+
+## Rollout and Recovery
+
+Apply migration `0035` before deploying the application changes. This order is backward compatible because all legitimate job writers already use `service_role`; any permission failure before the app deploy indicates an undocumented client write path that must be moved behind an API rather than re-enabled.
+
+After migration, verify the database acceptance matrix and monitor for permission errors, rising failed API requests, or queued jobs that stop progressing. Then deploy the route and form changes and exercise omission plus authorized reassignment.
+
+Rollback is forward-only. Do not restore authenticated job writes or the broken delete-trigger return. If an issue appears, ship a corrective migration while retaining the access restrictions; rolling back only the application bundle must not restore organization-clearing behavior.
 
 ## Non-Goals
 
@@ -67,3 +88,4 @@ Database-level behavior will also be checked when the migration is applied: auth
 - Allowing browser clients to mutate content-job state.
 - Rewriting applied migration history.
 - Changing approved-artifact immutability or publication immutability.
+- Building a general organization-transfer UI or changing quota ownership for jobs already reserved.

--- a/src/app/api/lessons/[lessonId]/route.ts
+++ b/src/app/api/lessons/[lessonId]/route.ts
@@ -1,17 +1,15 @@
 import { NextResponse, NextRequest } from "next/server";
-import { z } from 'zod';
+import { ZodError } from 'zod';
 import { getServerSession } from "@/lib/auth";
-import { createSSRUserSupabase } from "@/lib/supabase.server";
+import { createSSRUserSupabase, createServerSupabase } from "@/lib/supabase.server";
 import { mapLessonRecord } from '@/lib/lesson-record';
-
-const updateLessonSchema = z.object({
-    title: z.string().trim().min(1).max(160),
-    subject: z.string().trim().min(1).max(120),
-    gradeLevel: z.string().trim().min(1).max(80),
-    objectives: z.array(z.string().trim().min(1).max(500)).min(1).max(20),
-    content: z.string().max(100_000).nullable().default(null),
-    organizationId: z.string().uuid().nullable().optional(),
-});
+import {
+    hasRequiredOrganizationAdminMemberships,
+    isLessonOrganizationGuardError,
+    mapLessonUpdate,
+    requiredOrganizationAdminIds,
+    updateLessonSchema,
+} from '@/lib/lesson-update';
 
 export async function GET(
     request: NextRequest,
@@ -65,11 +63,11 @@ export async function PUT(
             );
         }
 
-        const supabase = await createSSRUserSupabase();
+        const userSupabase = await createSSRUserSupabase();
         const { lessonId } = await params;
-        const { data: existing, error: findErr } = await supabase
+        const { data: existing, error: findErr } = await userSupabase
             .from('lessons')
-            .select('id, teacher_id')
+            .select('id, teacher_id, organization_id')
             .eq('id', lessonId)
             .maybeSingle();
         if (findErr) throw findErr;
@@ -82,7 +80,7 @@ export async function PUT(
         }
 
         if (session.user.role === 'teacher') {
-            const { data: teacher, error: teacherError } = await supabase
+            const { data: teacher, error: teacherError } = await userSupabase
                 .from('teachers')
                 .select('user_id')
                 .eq('id', existing.teacher_id)
@@ -96,23 +94,58 @@ export async function PUT(
             }
         }
 
-        const body = updateLessonSchema.parse(await request.json());
-        const updateData = {
-            title: body.title,
-            subject: body.subject,
-            gradelevel: body.gradeLevel,
-            objectives: body.objectives,
-            content: body.content,
-            organization_id: body.organizationId ?? null,
-            updated_at: new Date().toISOString(),
-        };
-        const { data: updatedLesson, error } = await supabase
+        let body;
+        try {
+            body = updateLessonSchema.parse(await request.json());
+        } catch (error) {
+            if (error instanceof ZodError) {
+                return NextResponse.json(
+                    { error: 'Invalid lesson update' },
+                    { status: 400 },
+                );
+            }
+            throw error;
+        }
+
+        const requiredOrganizationIds = requiredOrganizationAdminIds({
+            actorRole: session.user.role,
+            currentOrganizationId: existing.organization_id,
+            update: body,
+        });
+        if (requiredOrganizationIds.length > 0) {
+            const trustedSupabase = createServerSupabase();
+            const { data: memberships, error: membershipError } = await trustedSupabase
+                .from('organization_members')
+                .select('organization_id, role, is_active')
+                .eq('user_id', session.user.id)
+                .in('organization_id', requiredOrganizationIds);
+            if (membershipError) throw membershipError;
+
+            if (!hasRequiredOrganizationAdminMemberships(requiredOrganizationIds, memberships ?? [])) {
+                return NextResponse.json(
+                    { error: 'Not authorized to reassign this lesson organization' },
+                    { status: 403 },
+                );
+            }
+        }
+
+        const organizationChangeRequested = Object.hasOwn(body, 'organizationId')
+            && body.organizationId !== existing.organization_id;
+        const { data: updatedLesson, error } = await userSupabase
             .from('lessons')
-            .update(updateData)
+            .update(mapLessonUpdate(body, new Date().toISOString()))
             .eq('id', lessonId)
             .select('*')
             .maybeSingle();
-        if (error) throw error;
+        if (error) {
+            if (isLessonOrganizationGuardError(error, organizationChangeRequested)) {
+                return NextResponse.json(
+                    { error: 'Not authorized to reassign this lesson organization' },
+                    { status: 403 },
+                );
+            }
+            throw error;
+        }
 
         return NextResponse.json(mapLessonRecord(updatedLesson));
     } catch (error) {

--- a/src/components/lessons/CreateLessonForm.tsx
+++ b/src/components/lessons/CreateLessonForm.tsx
@@ -23,7 +23,7 @@ import {
 import { Loader2, Plus, Trash2, Wand2, X } from "lucide-react";
 import { SupabaseSessionContext } from '@/components/providers/SupabaseAuthProvider';
 import { GRADE_LEVELS, SUBJECTS } from '@/lib/constants';
-import { mergeGeneratedLessonDraft } from '@/lib/lesson-artifacts/authoring-ui';
+import { buildLessonSubmissionPayload, mergeGeneratedLessonDraft } from '@/lib/lesson-artifacts/authoring-ui';
 
 interface Teacher {
   subjects?: string[];
@@ -150,14 +150,10 @@ export function CreateLessonForm({ onClose, lesson }: CreateLessonFormProps) {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          title,
-          subject,
-          gradeLevel,
-          objectives,
-          content: generatedContent,
-          organizationId: organizationId || null,
-        }),
+        body: JSON.stringify(buildLessonSubmissionPayload(
+          { title, subject, gradeLevel, objectives, content: generatedContent },
+          isEditing ? { mode: 'edit' } : { mode: 'create', organizationId },
+        )),
       });
 
       const result = await response.json().catch(() => ({}));

--- a/src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/authoring-ui.test.ts
@@ -1,11 +1,23 @@
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildLessonSubmissionPayload,
   isArtifactActionBusy,
+  type LessonSubmissionFields,
   mergeGeneratedLessonDraft,
   shouldApplyRemoteObjectives,
   summarizeContentJobs,
 } from '../authoring-ui';
+
+const fields = Object.freeze<LessonSubmissionFields>({
+  title: 'Comparing fractions',
+  subject: 'Mathematics',
+  gradeLevel: '5',
+  objectives: ['Compare fractions with unlike denominators'],
+  content: 'Use equivalent fractions to compare values.',
+});
 
 describe('Objective Studio state helpers', () => {
   it('tracks the active action separately for each artifact', () => {
@@ -43,5 +55,38 @@ describe('Objective Studio state helpers', () => {
       generated,
       replaceExisting: true,
     })).toEqual({ title: 'Manual title', objectives: ['Generated objective'], content: 'Generated content' });
+  });
+});
+
+describe('lesson submission payloads', () => {
+  it('omits organization ownership from edit payloads', () => {
+    const editPayload = buildLessonSubmissionPayload(fields, { mode: 'edit' });
+
+    expect(editPayload).toEqual(fields);
+    expect(Object.hasOwn(editPayload, 'organizationId')).toBe(false);
+    expect(Object.hasOwn(JSON.parse(JSON.stringify(editPayload)), 'organizationId')).toBe(false);
+  });
+
+  it('adds organization ownership only when creating a lesson', () => {
+    expect(buildLessonSubmissionPayload(fields, {
+      mode: 'create',
+      organizationId: '11111111-1111-4111-8111-111111111111',
+    })).toEqual({ ...fields, organizationId: '11111111-1111-4111-8111-111111111111' });
+
+    expect(buildLessonSubmissionPayload(fields, {
+      mode: 'create',
+      organizationId: '',
+    })).toEqual({ ...fields, organizationId: null });
+  });
+});
+
+describe('CreateLessonForm submission wiring', () => {
+  it('uses ownership-aware payload construction', () => {
+    const source = readFileSync(new URL('../../../components/lessons/CreateLessonForm.tsx', import.meta.url), 'utf8');
+
+    expect(source).toContain('buildLessonSubmissionPayload');
+    expect(source).toContain("{ mode: 'edit' }");
+    expect(source).toContain("{ mode: 'create', organizationId }");
+    expect(source).not.toContain('organizationId: organizationId || null');
   });
 });

--- a/src/lib/lesson-artifacts/__tests__/lesson-route-contract.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/lesson-route-contract.test.ts
@@ -13,11 +13,14 @@ describe('lesson mutation route ownership', () => {
     expect(route).not.toContain(".select('id, teacher')");
     expect(route).not.toMatch(/existing\.teacher(?!_)/);
     expect(route).not.toMatch(/lesson\.teacher(?!_)/);
-    expect(route).toContain(".select('id, teacher_id')");
+    expect(route).toContain(".select('id, teacher_id, organization_id')");
     expect(route).toContain(".from('teachers')");
     expect(route).toContain(".select('user_id')");
-    expect(route).toContain('gradelevel: body.gradeLevel');
-    expect(route).toContain('organization_id: body.organizationId');
+    expect(route).not.toContain('organization_id: body.organizationId ?? null');
+    expect(route).toContain('mapLessonUpdate(');
+    expect(route).toContain('isLessonOrganizationGuardError(');
+    expect(route).toContain('createServerSupabase');
+    expect(route).toContain('createSSRUserSupabase');
     expect(route).toContain('mapLessonRecord(updatedLesson)');
   });
 });

--- a/src/lib/lesson-artifacts/__tests__/lesson-update-route.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/lesson-update-route.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getServerSessionMock = vi.fn();
+const createSSRUserSupabaseMock = vi.fn();
+const createServerSupabaseMock = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  getServerSession: getServerSessionMock,
+}));
+
+vi.mock('@/lib/supabase.server', () => ({
+  createSSRUserSupabase: createSSRUserSupabaseMock,
+  createServerSupabase: createServerSupabaseMock,
+}));
+
+const lessonId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const sourceOrganizationId = '11111111-1111-4111-8111-111111111111';
+const targetOrganizationId = '22222222-2222-4222-8222-222222222222';
+const teacherId = '33333333-3333-4333-8333-333333333333';
+const userId = '44444444-4444-4444-8444-444444444444';
+const updateBody = {
+  title: 'Fractions',
+  subject: 'Mathematics',
+  gradeLevel: 'JHS 1',
+  objectives: ['Compare fractions'],
+  content: 'Lesson body',
+};
+
+type Result = { data: unknown; error: unknown };
+
+function maybeSingle(result: Result) {
+  return {
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  };
+}
+
+function createHarness(options: {
+  actorRole?: 'teacher' | 'admin';
+  currentOrganizationId?: string | null;
+  memberships?: unknown[];
+  membershipError?: unknown;
+  updateError?: unknown;
+}) {
+  const lessonLookup = {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => maybeSingle({
+        data: {
+          id: lessonId,
+          teacher_id: teacherId,
+          organization_id: options.currentOrganizationId === undefined
+            ? sourceOrganizationId
+            : options.currentOrganizationId,
+        },
+        error: null,
+      })),
+    })),
+  };
+  const teacherLookup = {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => maybeSingle({ data: { user_id: userId }, error: null })),
+    })),
+  };
+  const update = vi.fn(() => ({
+    eq: vi.fn(() => ({
+      select: vi.fn(() => maybeSingle({
+        data: {
+          id: lessonId,
+          teacher_id: teacherId,
+          organization_id: targetOrganizationId,
+          ...updateBody,
+          gradelevel: updateBody.gradeLevel,
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        error: options.updateError ?? null,
+      })),
+    })),
+  }));
+  const updateQuery = { update };
+  let lessonFromCalls = 0;
+  const userFrom = vi.fn((table: string) => {
+    if (table === 'lessons') return lessonFromCalls++ === 0 ? lessonLookup : updateQuery;
+    if (table === 'teachers') return teacherLookup;
+    throw new Error(`Unexpected authenticated table ${table}`);
+  });
+  const membershipLookup = {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        in: vi.fn().mockResolvedValue({
+          data: options.memberships ?? [],
+          error: options.membershipError ?? null,
+        }),
+      })),
+    })),
+  };
+  const trustedFrom = vi.fn((table: string) => {
+    if (table === 'organization_members') return membershipLookup;
+    throw new Error(`Unexpected trusted table ${table}`);
+  });
+
+  createSSRUserSupabaseMock.mockResolvedValue({ from: userFrom });
+  createServerSupabaseMock.mockReturnValue({ from: trustedFrom });
+  getServerSessionMock.mockResolvedValue({
+    user: {
+      id: userId,
+      role: options.actorRole ?? 'teacher',
+    },
+  });
+
+  return { update, membershipLookup, trustedFrom };
+}
+
+async function callPut(body: unknown) {
+  const { PUT } = await import('@/app/api/lessons/[lessonId]/route');
+  const response = await PUT(
+    new Request(`http://localhost/api/lessons/${lessonId}`, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    }) as never,
+    { params: Promise.resolve({ lessonId }) },
+  );
+
+  return { response, json: await response.json() };
+}
+
+describe('lesson PUT organization transfers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('preserves organization ownership and skips the trusted client when organizationId is omitted', async () => {
+    const harness = createHarness({ currentOrganizationId: sourceOrganizationId });
+
+    const { response } = await callPut(updateBody);
+
+    expect(response.status).toBe(200);
+    expect(createServerSupabaseMock).not.toHaveBeenCalled();
+    expect(harness.update).toHaveBeenCalledOnce();
+    const updateRow = (harness.update.mock.calls as unknown as [Record<string, unknown>][])[0][0];
+    expect(updateRow).not.toHaveProperty('organization_id');
+  });
+
+  it('skips membership lookup when the supplied organization UUID is unchanged', async () => {
+    const harness = createHarness({ currentOrganizationId: sourceOrganizationId });
+
+    const { response } = await callPut({ ...updateBody, organizationId: sourceOrganizationId });
+
+    expect(response.status).toBe(200);
+    expect(createServerSupabaseMock).not.toHaveBeenCalled();
+    expect(harness.update).toHaveBeenCalledOnce();
+  });
+
+  it('allows a teacher transfer with active source owner and target admin memberships', async () => {
+    const harness = createHarness({
+      currentOrganizationId: sourceOrganizationId,
+      memberships: [
+        { organization_id: sourceOrganizationId, role: 'owner', is_active: true },
+        { organization_id: targetOrganizationId, role: 'admin', is_active: true },
+      ],
+    });
+
+    const { response } = await callPut({ ...updateBody, organizationId: targetOrganizationId });
+
+    expect(response.status).toBe(200);
+    expect(harness.membershipLookup.select).toHaveBeenCalledWith('organization_id, role, is_active');
+    expect(harness.update).toHaveBeenCalledWith(expect.objectContaining({ organization_id: targetOrganizationId }));
+  });
+
+  it.each([
+    ['inactive source', [
+      { organization_id: sourceOrganizationId, role: 'owner', is_active: false },
+      { organization_id: targetOrganizationId, role: 'admin', is_active: true },
+    ]],
+    ['member target', [
+      { organization_id: sourceOrganizationId, role: 'owner', is_active: true },
+      { organization_id: targetOrganizationId, role: 'member', is_active: true },
+    ]],
+    ['missing source', [
+      { organization_id: targetOrganizationId, role: 'admin', is_active: true },
+    ]],
+    ['missing target', [
+      { organization_id: sourceOrganizationId, role: 'owner', is_active: true },
+    ]],
+  ])('denies a teacher transfer with %s membership', async (_case, memberships) => {
+    const harness = createHarness({ currentOrganizationId: sourceOrganizationId, memberships });
+
+    const { response, json } = await callPut({ ...updateBody, organizationId: targetOrganizationId });
+
+    expect(response.status).toBe(403);
+    expect(json).toEqual({ error: 'Not authorized to reassign this lesson organization' });
+    expect(harness.update).not.toHaveBeenCalled();
+  });
+
+  it('queries only the target organization when transferring an unowned lesson', async () => {
+    const harness = createHarness({
+      currentOrganizationId: null,
+      memberships: [{ organization_id: targetOrganizationId, role: 'owner', is_active: true }],
+    });
+
+    const { response } = await callPut({ ...updateBody, organizationId: targetOrganizationId });
+
+    expect(response.status).toBe(200);
+    const membershipFilter = harness.membershipLookup.select.mock.results[0].value.eq.mock.results[0].value.in;
+    expect(membershipFilter).toHaveBeenCalledWith('organization_id', [targetOrganizationId]);
+  });
+
+  it('lets a global admin transfer without a membership lookup', async () => {
+    const harness = createHarness({ actorRole: 'admin', currentOrganizationId: sourceOrganizationId });
+
+    const { response } = await callPut({ ...updateBody, organizationId: targetOrganizationId });
+
+    expect(response.status).toBe(200);
+    expect(createServerSupabaseMock).not.toHaveBeenCalled();
+    expect(harness.update).toHaveBeenCalledOnce();
+  });
+
+  it('returns 500 without updating when the membership lookup fails', async () => {
+    const harness = createHarness({
+      currentOrganizationId: sourceOrganizationId,
+      membershipError: { message: 'database unavailable' },
+    });
+
+    const { response, json } = await callPut({ ...updateBody, organizationId: targetOrganizationId });
+
+    expect(response.status).toBe(500);
+    expect(json).toEqual({ error: 'Failed to update lesson' });
+    expect(harness.update).not.toHaveBeenCalled();
+  });
+
+  it.each([null, 'not-a-uuid'])('returns stable 400 without updating for organizationId %j', async (organizationId) => {
+    const harness = createHarness({ currentOrganizationId: sourceOrganizationId });
+
+    const { response, json } = await callPut({ ...updateBody, organizationId });
+
+    expect(response.status).toBe(400);
+    expect(json).toEqual({ error: 'Invalid lesson update' });
+    expect(harness.update).not.toHaveBeenCalled();
+  });
+
+  it('maps a known organization guard error during a real transfer to 403', async () => {
+    const harness = createHarness({
+      actorRole: 'admin',
+      currentOrganizationId: sourceOrganizationId,
+      updateError: { code: '42501', message: 'Not authorized to reassign lesson organization' },
+    });
+
+    const { response, json } = await callPut({ ...updateBody, organizationId: targetOrganizationId });
+
+    expect(response.status).toBe(403);
+    expect(json).toEqual({ error: 'Not authorized to reassign this lesson organization' });
+  });
+
+  it('keeps a non-transfer 42501 error on the generic 500 path', async () => {
+    const harness = createHarness({
+      currentOrganizationId: sourceOrganizationId,
+      updateError: { code: '42501', message: 'Not authorized to reassign lesson organization' },
+    });
+
+    const { response, json } = await callPut(updateBody);
+
+    expect(response.status).toBe(500);
+    expect(json).toEqual({ error: 'Failed to update lesson' });
+  });
+
+  it('keeps an unknown 42501 transfer error on the generic 500 path', async () => {
+    const harness = createHarness({
+      actorRole: 'admin',
+      currentOrganizationId: sourceOrganizationId,
+      updateError: { code: '42501', message: 'permission denied for table lessons' },
+    });
+
+    const { response, json } = await callPut({ ...updateBody, organizationId: targetOrganizationId });
+
+    expect(response.status).toBe(500);
+    expect(json).toEqual({ error: 'Failed to update lesson' });
+  });
+});

--- a/src/lib/lesson-artifacts/__tests__/lesson-update.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/lesson-update.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasRequiredOrganizationAdminMemberships,
+  isLessonOrganizationGuardError,
+  mapLessonUpdate,
+  requiredOrganizationAdminIds,
+  updateLessonSchema,
+  type OrganizationAdminMembership,
+} from '@/lib/lesson-update';
+
+const organizationId = '11111111-1111-4111-8111-111111111111';
+const targetOrganizationId = '22222222-2222-4222-8222-222222222222';
+const updatedAt = '2026-07-12T10:00:00.000Z';
+const common = {
+  title: 'Fractions',
+  subject: 'Mathematics',
+  gradeLevel: 'JHS 1',
+  objectives: ['Compare fractions'],
+  content: 'Lesson body',
+};
+
+describe('lesson update policy', () => {
+  it('accepts omitted and UUID organization IDs but rejects null and malformed values', () => {
+    expect(updateLessonSchema.parse(common)).not.toHaveProperty('organizationId');
+    expect(updateLessonSchema.parse({ ...common, organizationId })).toMatchObject({ organizationId });
+    expect(() => updateLessonSchema.parse({ ...common, organizationId: null })).toThrow();
+    expect(() => updateLessonSchema.parse({ ...common, organizationId: 'not-a-uuid' })).toThrow();
+  });
+
+  it('maps only allowlisted fields and owns organization_id only for an explicit UUID', () => {
+    const omitted = mapLessonUpdate(updateLessonSchema.parse(common), updatedAt);
+    const explicit = mapLessonUpdate(updateLessonSchema.parse({ ...common, organizationId }), updatedAt);
+    const typedUndefined = mapLessonUpdate({ ...common, organizationId: undefined }, updatedAt);
+
+    expect(omitted).toEqual({
+      title: 'Fractions',
+      subject: 'Mathematics',
+      gradelevel: 'JHS 1',
+      objectives: ['Compare fractions'],
+      content: 'Lesson body',
+      updated_at: updatedAt,
+    });
+    expect(Object.hasOwn(omitted, 'organization_id')).toBe(false);
+    expect(explicit.organization_id).toBe(organizationId);
+    expect(Object.hasOwn(typedUndefined, 'organization_id')).toBe(false);
+  });
+
+  it('requires no membership lookup for omitted, same-organization, or global-admin updates', () => {
+    expect(requiredOrganizationAdminIds({
+      actorRole: 'teacher',
+      currentOrganizationId: organizationId,
+      update: updateLessonSchema.parse(common),
+    })).toEqual([]);
+    expect(requiredOrganizationAdminIds({
+      actorRole: 'teacher',
+      currentOrganizationId: organizationId,
+      update: updateLessonSchema.parse({ ...common, organizationId }),
+    })).toEqual([]);
+    expect(requiredOrganizationAdminIds({
+      actorRole: 'admin',
+      currentOrganizationId: organizationId,
+      update: updateLessonSchema.parse({ ...common, organizationId: targetOrganizationId }),
+    })).toEqual([]);
+  });
+
+  it('requires target-only membership for an unowned lesson and source plus target for teacher reassignment', () => {
+    expect(requiredOrganizationAdminIds({
+      actorRole: 'teacher',
+      currentOrganizationId: null,
+      update: updateLessonSchema.parse({ ...common, organizationId: targetOrganizationId }),
+    })).toEqual([targetOrganizationId]);
+    expect(requiredOrganizationAdminIds({
+      actorRole: 'teacher',
+      currentOrganizationId: organizationId,
+      update: updateLessonSchema.parse({ ...common, organizationId: targetOrganizationId }),
+    })).toEqual([organizationId, targetOrganizationId]);
+  });
+
+  it('requires active owner or admin membership in every required organization', () => {
+    const requiredIds = [organizationId, targetOrganizationId];
+    const ownerAndAdmin: OrganizationAdminMembership[] = [
+      { organization_id: organizationId, role: 'owner', is_active: true },
+      { organization_id: targetOrganizationId, role: 'admin', is_active: true },
+    ];
+
+    expect(hasRequiredOrganizationAdminMemberships(requiredIds, ownerAndAdmin)).toBe(true);
+    expect(hasRequiredOrganizationAdminMemberships(requiredIds, [ownerAndAdmin[1]])).toBe(false);
+    expect(hasRequiredOrganizationAdminMemberships(requiredIds, [
+      { organization_id: organizationId, role: 'owner', is_active: true },
+      { organization_id: targetOrganizationId, role: 'member', is_active: true },
+    ])).toBe(false);
+    expect(hasRequiredOrganizationAdminMemberships(requiredIds, [
+      { organization_id: organizationId, role: 'owner', is_active: false },
+      { organization_id: targetOrganizationId, role: 'admin', is_active: true },
+    ])).toBe(false);
+  });
+
+  it('classifies only known organization guard errors for real organization changes', () => {
+    expect(isLessonOrganizationGuardError(
+      { code: '42501', message: 'Active owner or admin membership in target organization is required' },
+      true,
+    )).toBe(true);
+    expect(isLessonOrganizationGuardError(
+      { code: '42501', message: 'Not authorized to reassign lesson organization' },
+      true,
+    )).toBe(true);
+    expect(isLessonOrganizationGuardError(
+      { code: '42501', message: 'Lesson organization cannot be cleared' },
+      true,
+    )).toBe(true);
+    expect(isLessonOrganizationGuardError(
+      { code: '42501', message: 'Active owner or admin membership in current organization is required' },
+      true,
+    )).toBe(true);
+    expect(isLessonOrganizationGuardError(
+      { code: '42501', message: 'permission denied for table lessons' },
+      true,
+    )).toBe(false);
+    expect(isLessonOrganizationGuardError(
+      { code: '42501', message: 'Active owner or admin membership in target organization is required' },
+      false,
+    )).toBe(false);
+    expect(isLessonOrganizationGuardError({ code: '42501' }, true)).toBe(false);
+  });
+});

--- a/src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/migration-hardening.test.ts
@@ -1,0 +1,96 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const migrationPath = join(
+  process.cwd(),
+  'supabase',
+  'migrations',
+  '0035_harden_lesson_artifact_writes.sql',
+);
+
+describe('lesson artifact write hardening migration', () => {
+  it('wraps all hardening changes in one transaction', async () => {
+    const sql = (await readFile(migrationPath, 'utf8')).trim();
+
+    expect(sql).toMatch(/^BEGIN;/i);
+    expect(sql).toMatch(/COMMIT;$/i);
+  });
+
+  it('limits content-job writes and mutating RPCs to service_role', async () => {
+    const sql = (await readFile(migrationPath, 'utf8')).toLowerCase();
+
+    expect(sql).toMatch(/drop policy if exists content_jobs_insert_own on public\.content_jobs;/);
+    expect(sql).toMatch(/drop policy if exists content_jobs_update_own on public\.content_jobs;/);
+    expect(sql).toMatch(/revoke all on table public\.content_jobs from public, anon, authenticated;/);
+    expect(sql).toMatch(/grant select on table public\.content_jobs to authenticated;/);
+    expect(sql).toMatch(/grant select, insert, update, delete on table public\.content_jobs to service_role;/);
+
+    for (const signature of [
+      'claim_content_jobs(text, integer, integer)',
+      'enqueue_content_jobs_with_usage(uuid, uuid, jsonb, jsonb)',
+      'create_uploaded_lesson_artifact(uuid, uuid, text, jsonb, jsonb, jsonb)',
+    ]) {
+      const escaped = signature.replace(/[()]/g, '\\$&').replace(/ /g, '\\s*');
+      expect(sql).toMatch(new RegExp(`revoke execute on function public\\.${escaped} from public, anon, authenticated;`));
+      expect(sql).toMatch(new RegExp(`grant execute on function public\\.${escaped} to service_role;`));
+    }
+  });
+
+  it('replaces browser lesson write policies with normalized manager controls', async () => {
+    const sql = (await readFile(migrationPath, 'utf8')).toLowerCase();
+
+    expect(sql).toContain('alter table public.lessons enable row level security;');
+    expect(sql).toMatch(/from pg_policies[\s\S]*tablename = 'lessons'[\s\S]*cmd in \('all', 'insert', 'update', 'delete'\)[\s\S]*public[\s\S]*anon[\s\S]*authenticated/);
+    expect(sql).toMatch(/execute format\('drop policy %i on public\.lessons', lesson_policy\.policyname\);/);
+    expect(sql).toMatch(/create policy lessons_manager_select on public\.lessons[\s\S]*for select[\s\S]*to authenticated[\s\S]*using \(public\.can_manage_lesson\(id\)\)/);
+    expect(sql).toMatch(/create policy lessons_manager_update on public\.lessons[\s\S]*for update[\s\S]*to authenticated[\s\S]*using \(public\.can_manage_lesson\(id\)\)[\s\S]*with check \(public\.can_assign_lesson_teacher\(teacher_id\)\)/);
+    expect(sql).toMatch(/create policy lessons_manager_delete on public\.lessons[\s\S]*for delete[\s\S]*to authenticated[\s\S]*using \(public\.can_manage_lesson\(id\)\)/);
+    expect(sql).not.toMatch(/create policy[\s\S]{0,120}on public\.lessons[\s\S]{0,120}for insert[\s\S]{0,120}to authenticated/);
+    const assignmentFunction = sql.match(
+      /create or replace function public\.can_assign_lesson_teacher\(p_teacher_id uuid\)[\s\S]*?as \$\$([\s\S]*?)\$\$;/,
+    )?.[1];
+
+    expect(assignmentFunction).toBeDefined();
+    expect(assignmentFunction).toMatch(/public\.users u[\s\S]*u\.id = auth\.uid\(\)[\s\S]*u\.role = 'admin'/);
+  });
+
+  it('allows authenticated lesson updates only for the safe column allowlist', async () => {
+    const sql = (await readFile(migrationPath, 'utf8')).toLowerCase();
+
+    expect(sql).toMatch(/revoke update on table public\.lessons from public, anon, authenticated;/);
+    expect(sql).toMatch(/from information_schema\.column_privileges[\s\S]*privilege_type = 'update'[\s\S]*grantee in \('public', 'anon', 'authenticated'\)/);
+    expect(sql).toMatch(/revoke update \(%i\) on table public\.lessons from %s/);
+    expect(sql).toMatch(/grant update \(title, subject, gradelevel, objectives, content, organization_id, updated_at\)\s+on table public\.lessons to authenticated;/);
+    expect(sql).not.toMatch(/grant update on table public\.lessons to authenticated;/);
+    expect(sql).not.toMatch(/grant update \([^)]*(teacher|teacher_id|current_publication_id)[^)]*\) on table public\.lessons to authenticated;/);
+    expect(sql).toMatch(/grant select, insert, update, delete on table public\.lessons to service_role;/);
+  });
+
+  it('guards lesson organization reassignment with source and target membership checks', async () => {
+    const sql = (await readFile(migrationPath, 'utf8')).toLowerCase();
+
+    expect(sql).toMatch(/create or replace function public\.prevent_invalid_lesson_organization_reassignment\(\)/);
+    expect(sql).toMatch(/raise exception using\s+errcode = '42501',\s+message = 'lesson organization cannot be cleared'/);
+    expect(sql).toContain('not authorized to reassign lesson organization');
+    expect(sql).toContain('active owner or admin membership in current organization is required');
+    expect(sql).toContain('active owner or admin membership in target organization is required');
+    expect(sql).toMatch(/if old\.organization_id is not distinct from new\.organization_id then[\s\S]*return new;/);
+    expect(sql).toMatch(/if auth\.role\(\) = 'service_role' then[\s\S]*return new;/);
+    expect(sql).toMatch(/if not public\.can_manage_lesson\(old\.id\) then/);
+    expect(sql).toMatch(/m\.role in \('owner', 'admin'\)[\s\S]*m\.is_active = true/);
+    expect(sql).toMatch(/drop trigger if exists lessons_organization_reassignment_guard on public\.lessons;/);
+    expect(sql).toMatch(/create trigger lessons_organization_reassignment_guard[\s\S]*before update of organization_id on public\.lessons/);
+  });
+
+  it('returns the correct row for non-approved artifact updates and deletes', async () => {
+    const sql = (await readFile(migrationPath, 'utf8')).toLowerCase();
+
+    expect(sql).toMatch(/create or replace function public\.prevent_approved_artifact_mutation\(\)/);
+    expect(sql).toMatch(/raise exception using\s+errcode = 'p0001',\s+message = 'approved lesson artifacts are immutable; create a new version'/);
+    expect(sql).toMatch(/if tg_op = 'delete' then[\s\S]*return old;[\s\S]*end if;[\s\S]*return new;/);
+    expect(sql).toMatch(/drop trigger if exists lesson_artifacts_approved_immutable on public\.lesson_artifacts;/);
+    expect(sql).toMatch(/create trigger lesson_artifacts_approved_immutable[\s\S]*before update or delete on public\.lesson_artifacts/);
+  });
+});

--- a/src/lib/lesson-artifacts/__tests__/worker-import.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/worker-import.test.ts
@@ -5,5 +5,5 @@ describe('standalone content worker imports', () => {
     const processor = await import('../job-processor');
 
     expect(processor.processContentJobBatch).toBeTypeOf('function');
-  });
+  }, 15_000);
 });

--- a/src/lib/lesson-artifacts/authoring-ui.ts
+++ b/src/lib/lesson-artifacts/authoring-ui.ts
@@ -22,6 +22,23 @@ export type ContentJobSummary = {
   active: number;
 };
 
+export type LessonSubmissionFields = {
+  title: string;
+  subject: string;
+  gradeLevel: string;
+  objectives: string[];
+  content: string;
+};
+
+export function buildLessonSubmissionPayload(
+  fields: LessonSubmissionFields,
+  operation: { mode: 'edit' } | { mode: 'create'; organizationId: string },
+): LessonSubmissionFields | (LessonSubmissionFields & { organizationId: string | null }) {
+  if (operation.mode === 'edit') return { ...fields };
+
+  return { ...fields, organizationId: operation.organizationId || null };
+}
+
 export function summarizeContentJobs(jobs: Array<{ status: string }>): ContentJobSummary {
   const succeeded = jobs.filter((job) => job.status === 'succeeded').length;
   const failed = jobs.filter((job) => job.status === 'failed').length;

--- a/src/lib/lesson-update.ts
+++ b/src/lib/lesson-update.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+
+import type { DBOrganizationMember } from '@/types/db';
+
+export const updateLessonSchema = z.object({
+  title: z.string().trim().min(1).max(160),
+  subject: z.string().trim().min(1).max(120),
+  gradeLevel: z.string().trim().min(1).max(80),
+  objectives: z.array(z.string().trim().min(1).max(500)).min(1).max(20),
+  content: z.string().max(100_000).nullable().default(null),
+  organizationId: z.string().uuid().optional(),
+});
+
+export type LessonUpdateInput = z.infer<typeof updateLessonSchema>;
+
+export type OrganizationAdminMembership = Pick<
+  DBOrganizationMember,
+  'organization_id' | 'role' | 'is_active'
+>;
+
+export function mapLessonUpdate(input: LessonUpdateInput, updatedAt: string) {
+  const row: {
+    title: string;
+    subject: string;
+    gradelevel: string;
+    objectives: string[];
+    content: string | null;
+    updated_at: string;
+    organization_id?: string;
+  } = {
+    title: input.title,
+    subject: input.subject,
+    gradelevel: input.gradeLevel,
+    objectives: input.objectives,
+    content: input.content,
+    updated_at: updatedAt,
+  };
+
+  if (Object.hasOwn(input, 'organizationId') && input.organizationId !== undefined) {
+    row.organization_id = input.organizationId;
+  }
+
+  return row;
+}
+
+export function requiredOrganizationAdminIds(input: {
+  actorRole: string | null;
+  currentOrganizationId: string | null;
+  update: Pick<LessonUpdateInput, 'organizationId'>;
+}): string[] {
+  if (!Object.hasOwn(input.update, 'organizationId')) return [];
+
+  const target = input.update.organizationId;
+  if (!target || target === input.currentOrganizationId || input.actorRole === 'admin') return [];
+
+  return [...new Set([input.currentOrganizationId, target].filter((id): id is string => Boolean(id)))];
+}
+
+export function hasRequiredOrganizationAdminMemberships(
+  requiredIds: string[],
+  memberships: OrganizationAdminMembership[],
+): boolean {
+  return requiredIds.every((organizationId) => memberships.some((membership) => (
+    membership.organization_id === organizationId
+    && membership.is_active
+    && (membership.role === 'owner' || membership.role === 'admin')
+  )));
+}
+
+const LESSON_ORGANIZATION_GUARD_MESSAGES = new Set([
+  'Not authorized to reassign lesson organization',
+  'Lesson organization cannot be cleared',
+  'Active owner or admin membership in current organization is required',
+  'Active owner or admin membership in target organization is required',
+]);
+
+export function isLessonOrganizationGuardError(
+  error: unknown,
+  organizationChangeRequested: boolean,
+): boolean {
+  if (!organizationChangeRequested || typeof error !== 'object' || error === null) return false;
+
+  const candidate = error as { code?: unknown; message?: unknown };
+  return candidate.code === '42501'
+    && typeof candidate.message === 'string'
+    && LESSON_ORGANIZATION_GUARD_MESSAGES.has(candidate.message);
+}

--- a/supabase/migrations/0035_harden_lesson_artifact_writes.sql
+++ b/supabase/migrations/0035_harden_lesson_artifact_writes.sql
@@ -1,0 +1,219 @@
+BEGIN;
+
+-- Browser clients may inspect their own jobs but must not create, lease, or edit them.
+DROP POLICY IF EXISTS content_jobs_insert_own ON public.content_jobs;
+DROP POLICY IF EXISTS content_jobs_update_own ON public.content_jobs;
+
+DO $$
+DECLARE
+  content_job_policy record;
+BEGIN
+  FOR content_job_policy IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'content_jobs'
+      AND cmd IN ('ALL', 'INSERT', 'UPDATE', 'DELETE')
+      AND roles && ARRAY['public', 'anon', 'authenticated']::name[]
+  LOOP
+    EXECUTE format('DROP POLICY %I ON public.content_jobs', content_job_policy.policyname);
+  END LOOP;
+END;
+$$;
+
+REVOKE ALL ON TABLE public.content_jobs FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.content_jobs TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.content_jobs TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.claim_content_jobs(text, integer, integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_content_jobs(text, integer, integer) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.enqueue_content_jobs_with_usage(uuid, uuid, jsonb, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.enqueue_content_jobs_with_usage(uuid, uuid, jsonb, jsonb) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.create_uploaded_lesson_artifact(uuid, uuid, text, jsonb, jsonb, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_uploaded_lesson_artifact(uuid, uuid, text, jsonb, jsonb, jsonb) TO service_role;
+
+ALTER TABLE public.lessons ENABLE ROW LEVEL SECURITY;
+
+-- Remove every existing browser-facing mutation policy by catalog metadata, not by policy name.
+DO $$
+DECLARE
+  lesson_policy record;
+BEGIN
+  FOR lesson_policy IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'lessons'
+      AND cmd IN ('ALL', 'INSERT', 'UPDATE', 'DELETE')
+      AND roles && ARRAY['public', 'anon', 'authenticated']::name[]
+  LOOP
+    EXECUTE format('DROP POLICY %I ON public.lessons', lesson_policy.policyname);
+  END LOOP;
+END;
+$$;
+
+DROP POLICY IF EXISTS lessons_manager_select ON public.lessons;
+DROP POLICY IF EXISTS lessons_manager_update ON public.lessons;
+DROP POLICY IF EXISTS lessons_manager_delete ON public.lessons;
+
+CREATE OR REPLACE FUNCTION public.can_assign_lesson_teacher(p_teacher_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT auth.role() = 'service_role' OR EXISTS (
+    SELECT 1
+    FROM public.teachers t
+    WHERE t.id = p_teacher_id
+      AND t.user_id = auth.uid()
+  ) OR EXISTS (
+    SELECT 1
+    FROM public.users u
+    WHERE u.id = auth.uid()
+      AND u.role = 'admin'
+  );
+$$;
+
+CREATE POLICY lessons_manager_select ON public.lessons
+  FOR SELECT TO authenticated
+  USING (public.can_manage_lesson(id));
+
+CREATE POLICY lessons_manager_update ON public.lessons
+  FOR UPDATE TO authenticated
+  USING (public.can_manage_lesson(id))
+  WITH CHECK (public.can_assign_lesson_teacher(teacher_id));
+
+CREATE POLICY lessons_manager_delete ON public.lessons
+  FOR DELETE TO authenticated
+  USING (public.can_manage_lesson(id));
+
+REVOKE UPDATE ON TABLE public.lessons FROM PUBLIC, anon, authenticated;
+
+-- Table-level REVOKE does not remove per-column UPDATE grants.
+DO $$
+DECLARE
+  lesson_column_grant record;
+BEGIN
+  FOR lesson_column_grant IN
+    SELECT DISTINCT column_name, grantee
+    FROM information_schema.column_privileges
+    WHERE table_schema = 'public'
+      AND table_name = 'lessons'
+      AND privilege_type = 'UPDATE'
+      AND grantee IN ('PUBLIC', 'anon', 'authenticated')
+  LOOP
+    EXECUTE format(
+      'REVOKE UPDATE (%I) ON TABLE public.lessons FROM %s',
+      lesson_column_grant.column_name,
+      CASE
+        WHEN lesson_column_grant.grantee = 'PUBLIC' THEN 'PUBLIC'
+        ELSE quote_ident(lesson_column_grant.grantee)
+      END
+    );
+  END LOOP;
+END;
+$$;
+
+GRANT UPDATE (title, subject, gradelevel, objectives, content, organization_id, updated_at)
+  ON TABLE public.lessons TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.lessons TO service_role;
+
+CREATE OR REPLACE FUNCTION public.prevent_invalid_lesson_organization_reassignment()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF OLD.organization_id IS NOT DISTINCT FROM NEW.organization_id THEN
+    RETURN NEW;
+  END IF;
+
+  IF auth.role() = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NOT public.can_manage_lesson(OLD.id) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'Not authorized to reassign lesson organization';
+  END IF;
+
+  IF NEW.organization_id IS NULL THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'Lesson organization cannot be cleared';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.users u
+    WHERE u.id = auth.uid()
+      AND u.role = 'admin'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  IF OLD.organization_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1
+    FROM public.organization_members m
+    WHERE m.organization_id = OLD.organization_id
+      AND m.user_id = auth.uid()
+      AND m.role IN ('owner', 'admin')
+      AND m.is_active = true
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'Active owner or admin membership in current organization is required';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.organization_members m
+    WHERE m.organization_id = NEW.organization_id
+      AND m.user_id = auth.uid()
+      AND m.role IN ('owner', 'admin')
+      AND m.is_active = true
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '42501',
+      MESSAGE = 'Active owner or admin membership in target organization is required';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS lessons_organization_reassignment_guard ON public.lessons;
+CREATE TRIGGER lessons_organization_reassignment_guard
+BEFORE UPDATE OF organization_id ON public.lessons
+FOR EACH ROW EXECUTE FUNCTION public.prevent_invalid_lesson_organization_reassignment();
+
+CREATE OR REPLACE FUNCTION public.prevent_approved_artifact_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF OLD.status = 'approved' THEN
+    RAISE EXCEPTION USING
+      ERRCODE = 'P0001',
+      MESSAGE = 'Approved lesson artifacts are immutable; create a new version';
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS lesson_artifacts_approved_immutable ON public.lesson_artifacts;
+CREATE TRIGGER lesson_artifacts_approved_immutable
+BEFORE UPDATE OR DELETE ON public.lesson_artifacts
+FOR EACH ROW EXECUTE FUNCTION public.prevent_approved_artifact_mutation();
+
+COMMIT;


### PR DESCRIPTION
## Summary

- preserve lesson organization ownership when teachers edit lessons
- authorize organization transfers through source and target admin memberships
- restrict browser content-job writes and protected lesson columns
- restore draft and rejected artifact deletion while keeping approved artifacts immutable
- stabilize the standalone worker cold-import test under full-suite contention

## Validation

- Vitest: 124/124 passing
- TypeScript: passing
- ESLint: 0 errors (existing warnings remain)
- Migration 0035 applied by the operator

## Verification note

The isolated canonical and upgrade PostgreSQL verifier runs were not performed because psql/disposable database access is unavailable; this was explicitly waived for this publish by the operator.