### PR TITLE
feat(learning): add objective-based sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ opencode.json
 /agents/live-class-agent/logs
 /agents/live-class-agent/tmp
 /agents/live-class-agent/tmp
+public/lesson-runtime/tailwind.generated.css

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "pnpm lesson-runtime:css",
     "dev": "next dev",
+    "prebuild": "pnpm lesson-runtime:css",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
@@ -11,7 +13,8 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "seed": "tsx scripts/seed.ts",
-    "worker:content": "tsx scripts/content-worker.ts"
+    "worker:content": "tsx scripts/content-worker.ts",
+    "lesson-runtime:css": "tailwindcss -c tailwind.lesson-runtime.config.ts -i src/styles/lesson-runtime.css -o public/lesson-runtime/tailwind.generated.css --minify"
   },
   "dependencies": {
     "@edusync/shared": "workspace:*",

--- a/src/app/api/content/route.ts
+++ b/src/app/api/content/route.ts
@@ -1,19 +1,17 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from '@/lib/auth';
+import { requireLessonViewer } from '@/lib/lesson-artifacts/lesson-read-server';
+import { lessonArtifactErrorResponse, LessonArtifactHttpError } from '@/lib/lesson-artifacts/server';
 import { createServerSupabase } from '@/lib/supabase.server';
 
 export async function GET(req: Request) {
     try {
-        const session = await getServerSession();
-        if (!session) {
-            return new NextResponse('Unauthorized', { status: 401 });
-        }
-
         const { searchParams } = new URL(req.url);
         const lessonId = searchParams.get('lessonId');
         const type = searchParams.get('type');
+        if (!lessonId) throw new LessonArtifactHttpError(400, 'lessonId is required');
 
-        const supabase = createServerSupabase();
+        const { supabase } = await requireLessonViewer(lessonId);
         let query = supabase.from('lesson_content').select('*');
         if (lessonId) query = query.eq('lesson_id', lessonId);
         if (type) query = query.eq('type', type);
@@ -22,7 +20,7 @@ export async function GET(req: Request) {
         return NextResponse.json(data ?? []);
     } catch (error) {
         console.error('Error fetching content:', error);
-        return new NextResponse('Internal Server Error', { status: 500 });
+        return lessonArtifactErrorResponse(error);
     }
 }
 

--- a/src/app/api/learning-runs/[runId]/artifacts/next/route.ts
+++ b/src/app/api/learning-runs/[runId]/artifacts/next/route.ts
@@ -8,6 +8,7 @@ import { rateLimit } from '@/lib/rate-limiter';
 const schema = z.object({
   kind: z.enum(['visualization', 'quiz']),
   requestId: z.string().trim().min(1).max(160),
+  taskDescription: z.string().trim().min(1).max(500).optional(),
 });
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ runId: string }> }) {

--- a/src/app/api/learning-runs/route.ts
+++ b/src/app/api/learning-runs/route.ts
@@ -4,8 +4,17 @@ import { z } from 'zod';
 import { requireStudentSession } from '@/lib/lesson-artifacts/learning-server';
 import { lessonArtifactErrorResponse, LessonArtifactHttpError } from '@/lib/lesson-artifacts/server';
 import { createServerSupabase } from '@/lib/supabase.server';
+import {
+  isObjectiveSelectionChange,
+  normalizePublishedObjectives,
+  selectPublishedObjective,
+} from '@/lib/lesson-artifacts/student-learning';
 
-const schema = z.object({ lessonId: z.string().uuid(), mode: z.enum(['companion', 'tutor']).default('tutor') });
+const schema = z.object({
+  lessonId: z.string().uuid(),
+  mode: z.enum(['companion', 'tutor']).default('tutor'),
+  objectiveId: z.string().uuid().optional(),
+});
 
 export async function POST(request: Request) {
   try {
@@ -28,8 +37,15 @@ export async function POST(request: Request) {
       .eq('id', lesson.current_publication_id)
       .single();
     if (publicationError) throw publicationError;
-    const firstObjective = publication.manifest?.objectives?.[0];
-    if (!firstObjective) throw new LessonArtifactHttpError(409, 'Published lesson has no objectives');
+    const publishedObjectives = normalizePublishedObjectives(publication.manifest?.objectives ?? []);
+    if (!publishedObjectives) {
+      throw new LessonArtifactHttpError(409, 'The published lesson snapshot needs to be republished');
+    }
+    const selectedObjective = selectPublishedObjective(publishedObjectives, input.objectiveId);
+    if (!selectedObjective) {
+      if (input.objectiveId) throw new LessonArtifactHttpError(400, 'Objective is not part of this publication');
+      throw new LessonArtifactHttpError(409, 'Published lesson has no objectives');
+    }
 
     const { data: existing } = await supabase
       .from('learning_runs')
@@ -48,13 +64,46 @@ export async function POST(request: Request) {
         student_id: session.user.id,
         lesson_id: lesson.id,
         publication_id: publication.id,
-        active_objective_id: firstObjective.id,
+        active_objective_id: selectedObjective.id,
         mode: input.mode,
       }).select('*').single();
       if (result.error) throw result.error;
       run = result.data;
+    } else if (isObjectiveSelectionChange(run.active_objective_id, selectedObjective.id)) {
+      const previousObjectiveId = run.active_objective_id;
+      const { data: updated, error: updateError } = await supabase
+        .from('learning_runs')
+        .update({ active_objective_id: selectedObjective.id, updated_at: new Date().toISOString() })
+        .eq('id', run.id)
+        .eq('student_id', session.user.id)
+        .select('*')
+        .single();
+      if (updateError) throw updateError;
+      run = updated;
+      const { error: eventError } = await supabase.from('learning_events').insert({
+        run_id: run.id,
+        student_id: session.user.id,
+        lesson_id: lesson.id,
+        objective_id: selectedObjective.id,
+        objective_revision: selectedObjective.revision,
+        event_type: 'objective_changed',
+        payload: { position: selectedObjective.position },
+      });
+      if (eventError) {
+        const { error: rollbackError } = await supabase
+          .from('learning_runs')
+          .update({ active_objective_id: previousObjectiveId, updated_at: new Date().toISOString() })
+          .eq('id', run.id)
+          .eq('student_id', session.user.id)
+          .select('*')
+          .single();
+        if (rollbackError) {
+          throw new Error(`Objective event failed and the run could not be restored: ${rollbackError.message}`);
+        }
+        throw eventError;
+      }
     }
-    return NextResponse.json({ run, lesson, objectives: publication.manifest.objectives, publicationVersion: publication.version });
+    return NextResponse.json({ run, lesson, objectives: publishedObjectives, publicationVersion: publication.version });
   } catch (error) {
     return lessonArtifactErrorResponse(error);
   }

--- a/src/app/api/resources/route.ts
+++ b/src/app/api/resources/route.ts
@@ -1,18 +1,16 @@
 import { NextResponse } from 'next/server';
 import { getServerSession } from '@/lib/auth';
+import { requireLessonViewer } from '@/lib/lesson-artifacts/lesson-read-server';
+import { lessonArtifactErrorResponse, LessonArtifactHttpError } from '@/lib/lesson-artifacts/server';
 import { createServerSupabase } from '@/lib/supabase.server';
 
 export async function GET(req: Request) {
     try {
-        const session = await getServerSession();
-        if (!session) {
-            return new NextResponse('Unauthorized', { status: 401 });
-        }
-
         const { searchParams } = new URL(req.url);
         const lessonId = searchParams.get('lessonId');
+        if (!lessonId) throw new LessonArtifactHttpError(400, 'lessonId is required');
 
-        const supabase = createServerSupabase();
+        const { supabase } = await requireLessonViewer(lessonId);
 
         // Check if resources table exists - return empty array if not
         const { data, error } = await supabase
@@ -29,7 +27,7 @@ export async function GET(req: Request) {
         return NextResponse.json(data ?? []);
     } catch (error) {
         console.error('Error fetching resources:', error);
-        return NextResponse.json([]);
+        return lessonArtifactErrorResponse(error);
     }
 }
 

--- a/src/app/api/students/lessons/[lessonId]/route.ts
+++ b/src/app/api/students/lessons/[lessonId]/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+
+import { requireStudentSession } from '@/lib/lesson-artifacts/learning-server';
+import {
+  buildStudentLessonDetail,
+  normalizePublishedObjectives,
+} from '@/lib/lesson-artifacts/student-learning';
+import {
+  lessonArtifactErrorResponse,
+  LessonArtifactHttpError,
+} from '@/lib/lesson-artifacts/server';
+import { createServerSupabase } from '@/lib/supabase.server';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ lessonId: string }> },
+) {
+  try {
+    const session = await requireStudentSession();
+    const { lessonId } = await params;
+    const supabase = createServerSupabase();
+    const [{ data: lesson, error: lessonError }, { data: student, error: studentError }] = await Promise.all([
+      supabase
+        .from('lessons')
+        .select('id,gradelevel,current_publication_id')
+        .eq('id', lessonId)
+        .maybeSingle(),
+      supabase
+        .from('students')
+        .select('grade')
+        .eq('user_id', session.user.id)
+        .maybeSingle(),
+    ]);
+
+    if (lessonError) throw lessonError;
+    if (studentError) throw studentError;
+    if (!lesson) throw new LessonArtifactHttpError(404, 'Lesson not found');
+
+    const lessonGrade = lesson.gradelevel?.trim().toLowerCase();
+    const studentGrade = student?.grade?.trim().toLowerCase();
+    if (!lessonGrade || !studentGrade || lessonGrade !== studentGrade) {
+      throw new LessonArtifactHttpError(403, 'This lesson is not assigned to your grade');
+    }
+
+    if (!lesson.current_publication_id) {
+      return NextResponse.json(
+        { error: 'This lesson has not been published yet', code: 'unpublished_lesson' },
+        { status: 409 },
+      );
+    }
+
+    const { data: publication, error: publicationError } = await supabase
+      .from('lesson_publications')
+      .select('version,manifest')
+      .eq('id', lesson.current_publication_id)
+      .maybeSingle();
+    if (publicationError) throw publicationError;
+    if (!publication?.manifest?.lesson) {
+      return NextResponse.json(
+        { error: 'The published lesson snapshot is unavailable', code: 'unpublished_lesson' },
+        { status: 409 },
+      );
+    }
+
+    const objectives = normalizePublishedObjectives(publication.manifest.objectives ?? []);
+    if (!objectives) {
+      return NextResponse.json(
+        { error: 'The published lesson snapshot needs to be republished', code: 'unpublished_lesson' },
+        { status: 409 },
+      );
+    }
+    const artifactIds = [...new Set(objectives.flatMap((objective) => objective.artifactIds ?? []))];
+    const artifactResult = artifactIds.length
+      ? await supabase.from('lesson_artifacts').select('id,kind').in('id', artifactIds)
+      : { data: [], error: null };
+    if (artifactResult.error) throw artifactResult.error;
+
+    return NextResponse.json(buildStudentLessonDetail({
+      publicationVersion: publication.version,
+      manifest: {
+        lesson: publication.manifest.lesson,
+        objectives,
+      },
+      artifacts: artifactResult.data ?? [],
+    }));
+  } catch (error) {
+    return lessonArtifactErrorResponse(error);
+  }
+}

--- a/src/app/api/tutor/route.ts
+++ b/src/app/api/tutor/route.ts
@@ -242,6 +242,7 @@ export async function POST(req: NextRequest) {
                         runId: parsedBody.data.learningRunId,
                         kind: artifactKind,
                         requestId: `tutor:${persistedChatId}:${randomUUID()}`,
+                        taskDescription: vizReq?.taskDescription || userMessage.content,
                     });
                     if ('artifact' in attachment) {
                         tutorMessage.learningArtifacts = [attachment];

--- a/src/app/students/dashboard/page.tsx
+++ b/src/app/students/dashboard/page.tsx
@@ -16,20 +16,29 @@ import {
 } from "@/components/ui/card";
 import { BookOpen, Brain, MessagesSquare, Trophy, Clock, FileText } from "lucide-react";
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { useStudentProfile } from '@/hooks/useStudentProfile';
+import { resolveStudentDisplayName } from '@/lib/student-profile';
 
 export default function StudentDashboard() {
   const session = useContext(SupabaseSessionContext);
   const router = useRouter();
+  const { data: profile } = useStudentProfile(session?.user?.id);
 
   if (!session) {
     return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
   }
 
+  const displayName = resolveStudentDisplayName({
+    profileName: profile?.name,
+    metadataName: session.user.user_metadata?.name,
+    email: profile?.email ?? session.user.email,
+  });
+
   return (
     <DashboardLayout>
       <div className="p-6">
         <div className="mb-6">
-          <h2 className="text-3xl font-bold text-foreground">Welcome back, {session?.user?.name}!</h2>
+          <h2 className="text-3xl font-bold text-foreground">Welcome back, {displayName}!</h2>
           <p className="text-muted-foreground">Here's an overview of your learning journey</p>
         </div>
 
@@ -174,4 +183,4 @@ export default function StudentDashboard() {
       </div>
     </DashboardLayout>
   );
-} 
+}

--- a/src/app/students/learn/page.tsx
+++ b/src/app/students/learn/page.tsx
@@ -48,14 +48,7 @@ function LessonSelector({ onSelectLesson }: { onSelectLesson: (lesson: Lesson) =
   );
 
   const handleSelectLesson = (lesson: Lesson) => {
-    const params = new URLSearchParams({
-      lessonId: lesson.id,
-      lessonTitle: lesson.title,
-      lessonSubject: lesson.subject,
-      lessonGrade: lesson.gradelevel,
-      lessonObjectives: lesson.objectives || '',
-    });
-    router.push(`/students/learn?${params.toString()}`);
+    router.push(`/students/lessons/${lesson.id}`);
   };
 
   const handleStartWithoutLesson = () => {

--- a/src/app/students/lessons/[lessonId]/page.tsx
+++ b/src/app/students/lessons/[lessonId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, use, useContext } from 'react';
+import { useState, useEffect, use, useCallback, useContext } from 'react';
 import { useRouter } from 'next/navigation';
 import { SupabaseSessionContext } from '@/components/providers/SupabaseAuthProvider';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
@@ -16,7 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useToast } from '@/components/ui/use-toast';
 import { PracticeExercise } from '@/components/practice/PracticeExercise';
 import { ContentDisplay } from '@/components/content/ContentDisplay';
-import { Loader2, FileText, Link as LinkIcon, ExternalLink, Sparkles } from 'lucide-react';
+import { CircleHelp, ExternalLink, FileText, Link as LinkIcon, Loader2, Play, Presentation, Sparkles, Target } from 'lucide-react';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import { FloatingActionButton } from '@/components/ui/floating-action-button';
@@ -26,6 +26,7 @@ import type {
   ExplanationContentType, 
   SummaryContentType 
 } from '@/components/content/types';
+import type { StudentLessonDetail } from '@/lib/lesson-artifacts/student-learning';
 
 interface Resource {
   _id: string;
@@ -48,55 +49,40 @@ interface LessonContent {
   lessonId: string;
 }
 
-interface Lesson {
-  id: string;
-  title: string;
-  subject: string;
-  gradelevel: string;
-  objectives: string;
-  content: string;
-}
-
 export default function LessonPage({ params }: { params: Promise<{ lessonId: string }> }) {
   const resolvedParams = use(params);
   const session = useContext(SupabaseSessionContext);
   const router = useRouter();
   const { toast } = useToast();
-  const [lesson, setLesson] = useState<Lesson | null>(null);
+  const [lessonDetail, setLessonDetail] = useState<StudentLessonDetail | null>(null);
+  const [lessonError, setLessonError] = useState<string | null>(null);
   const [contents, setContents] = useState<LessonContent[]>([]);
   const [resources, setResources] = useState<Resource[]>([]);
   const [loading, setLoading] = useState(true);
   const [practicing, setPracticing] = useState(false);
   const [questions, setQuestions] = useState<any[]>([]);
   const [generatingPractice, setGeneratingPractice] = useState(false);
+  const lesson = lessonDetail?.lesson ?? null;
 
-  useEffect(() => {
-    if (resolvedParams.lessonId) {
-      fetchLesson();
-      fetchContent();
-      fetchResources();
-    }
-  }, [resolvedParams.lessonId]);
-
-  const fetchLesson = async () => {
+  const fetchLesson = useCallback(async () => {
     try {
-      const response = await fetch(`/api/lessons/${resolvedParams.lessonId}`);
-      if (!response.ok) throw new Error('Failed to fetch lesson');
-      const data = await response.json();
-      setLesson(data);
+      setLoading(true);
+      setLessonError(null);
+      const response = await fetch(`/api/students/lessons/${resolvedParams.lessonId}`);
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(body.error || 'Failed to fetch lesson');
+      setLessonDetail(body as StudentLessonDetail);
+      return true;
     } catch (error) {
       console.error('Error fetching lesson:', error);
-      toast({
-        title: 'Error',
-        description: 'Failed to load lesson details',
-        variant: 'destructive',
-      });
+      setLessonError(error instanceof Error ? error.message : 'Failed to load lesson details');
+      return false;
     } finally {
       setLoading(false);
     }
-  };
+  }, [resolvedParams.lessonId]);
 
-  const fetchContent = async () => {
+  const fetchContent = useCallback(async () => {
     try {
       const response = await fetch(`/api/content?lessonId=${resolvedParams.lessonId}`);
       if (!response.ok) throw new Error('Failed to fetch content');
@@ -110,9 +96,9 @@ export default function LessonPage({ params }: { params: Promise<{ lessonId: str
         variant: 'destructive',
       });
     }
-  };
+  }, [resolvedParams.lessonId, toast]);
 
-  const fetchResources = async () => {
+  const fetchResources = useCallback(async () => {
     try {
       const response = await fetch(`/api/resources?lessonId=${resolvedParams.lessonId}`);
       if (!response.ok) throw new Error('Failed to fetch resources');
@@ -126,7 +112,16 @@ export default function LessonPage({ params }: { params: Promise<{ lessonId: str
         variant: 'destructive',
       });
     }
-  };
+  }, [resolvedParams.lessonId, toast]);
+
+  useEffect(() => {
+    if (resolvedParams.lessonId) {
+      void (async () => {
+        const authorized = await fetchLesson();
+        if (authorized) await Promise.all([fetchContent(), fetchResources()]);
+      })();
+    }
+  }, [fetchContent, fetchLesson, fetchResources, resolvedParams.lessonId]);
 
   const handleStartPractice = async (isRetry = false) => {
     if (!lesson) return;
@@ -183,14 +178,13 @@ export default function LessonPage({ params }: { params: Promise<{ lessonId: str
     handleStartPractice();
   };
 
-  const handleLearnWithAI = () => {
+  const handleLearnWithAI = (objectiveId?: string) => {
     if (!lesson) return;
+    const selectedObjectiveId = objectiveId ?? lessonDetail?.objectives[0]?.id;
+    if (!selectedObjectiveId) return;
     const params = new URLSearchParams({
       lessonId: resolvedParams.lessonId,
-      lessonTitle: lesson.title,
-      lessonSubject: lesson.subject,
-      lessonGrade: lesson.gradelevel,
-      lessonObjectives: lesson.objectives || '',
+      objectiveId: selectedObjectiveId,
     });
     router.push(`/students/learn?${params.toString()}`);
   };
@@ -208,11 +202,17 @@ export default function LessonPage({ params }: { params: Promise<{ lessonId: str
   if (!lesson) {
     return (
       <DashboardLayout>
-        <div className="p-6">
-          <h2 className="text-2xl font-bold mb-4">Lesson not found</h2>
-          <Button onClick={() => window.location.assign('/students/lessons')}>
-            Back to Lessons
-          </Button>
+        <div className="mx-auto flex min-h-[70vh] max-w-xl items-center p-6">
+          <Card className="w-full border-amber-200 bg-amber-50/60 dark:border-amber-900 dark:bg-amber-950/20">
+            <CardHeader>
+              <CardTitle>Lesson unavailable</CardTitle>
+              <CardDescription>{lessonError || 'This lesson could not be found.'}</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-3">
+              <Button onClick={fetchLesson}>Try again</Button>
+              <Button variant="outline" onClick={() => window.location.assign('/students/lessons')}>Back to lessons</Button>
+            </CardContent>
+          </Card>
         </div>
       </DashboardLayout>
     );
@@ -259,7 +259,7 @@ export default function LessonPage({ params }: { params: Promise<{ lessonId: str
           <CardHeader>
             <CardTitle>{lesson.title}</CardTitle>
             <CardDescription>
-              {lesson.subject} • Grade {lesson.gradelevel}
+              {lesson.subject} • Grade {lesson.gradeLevel}
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -271,12 +271,41 @@ export default function LessonPage({ params }: { params: Promise<{ lessonId: str
                 <TabsTrigger value="practice">Practice</TabsTrigger>
               </TabsList>
 
-              <TabsContent value="overview" className="space-y-4">
-                <div>
-                  <h3 className="font-semibold mb-2">Learning Objectives</h3>
-                  <div className="prose prose-sm max-w-none">
-                    <ReactMarkdown>{typeof lesson.objectives === 'string' ? lesson.objectives : JSON.stringify(lesson.objectives)}</ReactMarkdown>
+              <TabsContent value="overview" className="space-y-6">
+                <section className="overflow-hidden rounded-2xl border bg-gradient-to-br from-slate-950 via-slate-900 to-emerald-950 text-white shadow-sm">
+                  <div className="grid gap-6 p-6 md:grid-cols-[1fr_auto] md:items-end">
+                    <div>
+                      <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.22em] text-lime-300">
+                        <Target className="h-4 w-4" /> Objective roadmap
+                      </div>
+                      <h3 className="max-w-2xl text-2xl font-semibold leading-tight">Learn one clear outcome at a time.</h3>
+                      <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">Each tutor session stays focused on one objective and uses your teacher&apos;s reviewed activities before creating anything new.</p>
+                    </div>
+                    <Button className="bg-lime-300 text-slate-950 hover:bg-lime-200" onClick={() => handleLearnWithAI()} disabled={!lessonDetail?.objectives.length}>
+                      <Play className="mr-2 h-4 w-4 fill-current" /> Start lesson with AI
+                    </Button>
                   </div>
+                </section>
+
+                <div className="space-y-3">
+                  {lessonDetail?.objectives.map((objective, index) => (
+                    <Card key={objective.id} className="group overflow-hidden transition hover:-translate-y-0.5 hover:border-emerald-300 hover:shadow-md dark:hover:border-emerald-700">
+                      <CardContent className="grid gap-4 p-5 sm:grid-cols-[auto_1fr_auto] sm:items-center">
+                        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950 text-sm font-bold text-lime-300 shadow-sm dark:bg-lime-300 dark:text-slate-950">{String(index + 1).padStart(2, '0')}</div>
+                        <div className="min-w-0">
+                          <p className="font-medium leading-6 text-foreground">{objective.text}</p>
+                          <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                            <span className="inline-flex items-center gap-1.5 rounded-full border bg-muted/40 px-2.5 py-1"><Presentation className="h-3.5 w-3.5" />{objective.artifactCounts.visualizations} visual{objective.artifactCounts.visualizations === 1 ? '' : 's'}</span>
+                            <span className="inline-flex items-center gap-1.5 rounded-full border bg-muted/40 px-2.5 py-1"><CircleHelp className="h-3.5 w-3.5" />{objective.artifactCounts.quizzes} quiz{objective.artifactCounts.quizzes === 1 ? '' : 'zes'}</span>
+                          </div>
+                        </div>
+                        <Button variant="outline" className="w-full sm:w-auto" onClick={() => handleLearnWithAI(objective.id)}>
+                          <Sparkles className="mr-2 h-4 w-4" /> Start AI tutor
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  ))}
+                  {!lessonDetail?.objectives.length && <p className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">No published objectives are available for this lesson.</p>}
                 </div>
                 {lesson.content && (
                   <div>
@@ -416,9 +445,9 @@ export default function LessonPage({ params }: { params: Promise<{ lessonId: str
         <FloatingActionButton
           icon={<Sparkles className="w-5 h-5" />}
           label="Learn with AI"
-          onClick={handleLearnWithAI}
+          onClick={() => handleLearnWithAI()}
         />
       )}
     </DashboardLayout>
   );
-} 
+}

--- a/src/components/learn/StudentInteractiveAITutor.tsx
+++ b/src/components/learn/StudentInteractiveAITutor.tsx
@@ -1,10 +1,13 @@
 'use client';
 
-import { useEffect, useState, Suspense } from 'react';
-import { Loader2 } from 'lucide-react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import { LessonContext } from '@/hooks/useAudioStreaming';
 import { TutorExperience } from '@/components/learn/tutor/TutorExperience';
+import { useObjectiveLearning } from '@/hooks/useObjectiveLearning';
+import type { StudentLessonDetail } from '@/lib/lesson-artifacts/student-learning';
+import { Button } from '@/components/ui/button';
 
 type StudentInteractiveAITutorProps = {
   onSessionStarted?: (sessionId: string) => void;
@@ -17,15 +20,17 @@ export const StudentInteractiveAITutorComponent = ({ onSessionStarted, onSession
   const debugMode = searchParams.get('debug') === 'true';
   const getFeedback = searchParams.get('getFeedback') === 'true';
 
-  // Parse lesson context from URL params
   const lessonIdFromUrl = searchParams.get('lessonId');
-  const lessonTitleFromUrl = searchParams.get('lessonTitle');
-  const lessonSubjectFromUrl = searchParams.get('lessonSubject');
-  const lessonGradeFromUrl = searchParams.get('lessonGrade');
-  const lessonObjectivesFromUrl = searchParams.get('lessonObjectives');
+  const objectiveIdFromUrl = searchParams.get('objectiveId');
+  const objectiveLearning = useObjectiveLearning({
+    lessonId: lessonIdFromUrl,
+    objectiveId: objectiveIdFromUrl,
+    mode: 'tutor',
+  });
 
-  const [lessonContext, setLessonContext] = useState<LessonContext | undefined>(initialLessonContext);
+  const [lessonDetail, setLessonDetail] = useState<StudentLessonDetail | null>(null);
   const [lessonLoading, setLessonLoading] = useState(!!lessonIdFromUrl);
+  const [lessonError, setLessonError] = useState<string | null>(null);
 
   // Fetch lesson content if lessonId is provided
   useEffect(() => {
@@ -37,31 +42,14 @@ export const StudentInteractiveAITutorComponent = ({ onSessionStarted, onSession
 
       try {
         setLessonLoading(true);
-        const response = await fetch(`/api/lessons/${lessonIdFromUrl}`);
-        if (response.ok) {
-          const lesson = await response.json();
-          const context: LessonContext = {
-            lessonId: lessonIdFromUrl,
-            title: lesson.title,
-            subject: lesson.subject,
-            gradeLevel: lesson.gradelevel,
-            objectives: lesson.objectives,
-            content: lesson.content,
-          };
-          setLessonContext(context);
-        }
+        setLessonError(null);
+        const response = await fetch(`/api/students/lessons/${lessonIdFromUrl}`);
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(data.error || 'Failed to load lesson');
+        setLessonDetail(data);
       } catch (error) {
         console.error('Failed to fetch lesson:', error);
-        // Fall back to URL params if fetch fails
-        if (lessonTitleFromUrl) {
-          setLessonContext({
-            lessonId: lessonIdFromUrl,
-            title: lessonTitleFromUrl,
-            subject: lessonSubjectFromUrl || undefined,
-            gradeLevel: lessonGradeFromUrl || undefined,
-            objectives: lessonObjectivesFromUrl || undefined,
-          });
-        }
+        setLessonError(error instanceof Error ? error.message : 'Failed to load lesson');
       } finally {
         setLessonLoading(false);
       }
@@ -70,13 +58,43 @@ export const StudentInteractiveAITutorComponent = ({ onSessionStarted, onSession
     fetchLessonContent();
   }, [lessonIdFromUrl]);
 
-  // Show loading state while fetching lesson
-  if (lessonLoading) {
+  const lessonContext = useMemo<LessonContext | undefined>(() => {
+    if (!lessonDetail) return initialLessonContext;
+    return {
+      lessonId: lessonDetail.lesson.id,
+      title: lessonDetail.lesson.title,
+      subject: lessonDetail.lesson.subject,
+      gradeLevel: lessonDetail.lesson.gradeLevel,
+      objectives: lessonDetail.objectives.map((objective) => objective.text),
+      content: lessonDetail.lesson.content ?? undefined,
+      learningRunId: objectiveLearning.runId ?? undefined,
+      activeObjective: objectiveLearning.activeObjective ?? undefined,
+    };
+  }, [initialLessonContext, lessonDetail, objectiveLearning.activeObjective, objectiveLearning.runId]);
+
+  if (lessonLoading || objectiveLearning.loading) {
     return (
       <div className="flex h-screen items-center justify-center bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-700">
         <div className="flex flex-col items-center gap-4">
           <Loader2 className="w-12 h-12 animate-spin text-primary" />
           <p className="text-muted-foreground">Loading lesson...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const blockingError = lessonError || objectiveLearning.error;
+  if (lessonIdFromUrl && blockingError && !lessonContext?.learningRunId) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-slate-950 p-6 text-white">
+        <div className="w-full max-w-md rounded-3xl border border-amber-300/20 bg-white/5 p-7 text-center shadow-2xl">
+          <AlertTriangle className="mx-auto h-10 w-10 text-amber-300" />
+          <h1 className="mt-4 text-xl font-semibold">Tutor session unavailable</h1>
+          <p className="mt-2 text-sm leading-6 text-slate-300">{blockingError}</p>
+          <div className="mt-6 flex justify-center gap-3">
+            <Button onClick={() => window.location.reload()}>Try again</Button>
+            <Button variant="outline" className="border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white" onClick={() => window.location.assign(`/students/lessons/${lessonIdFromUrl}`)}>Back to lesson</Button>
+          </div>
         </div>
       </div>
     );
@@ -88,8 +106,9 @@ export const StudentInteractiveAITutorComponent = ({ onSessionStarted, onSession
       apiKey={null}
       getFeedback={getFeedback}
       debugMode={debugMode}
-      initialTopic={lessonTitleFromUrl || lessonContext?.title || null}
+      initialTopic={lessonContext?.activeObjective?.text || lessonContext?.title || null}
       lessonContext={lessonContext}
+      objectiveLearning={lessonContext?.learningRunId ? objectiveLearning : undefined}
       onSessionStarted={onSessionStarted}
       onSessionEnded={onSessionEnded}
     />

--- a/src/components/learn/tutor/TutorExperience.tsx
+++ b/src/components/learn/tutor/TutorExperience.tsx
@@ -8,11 +8,14 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { VoiceControl } from '@/components/voice/VoiceControl';
 import { StartButtonOverlay } from '@/components/voice/StartButtonOverlay';
 import { FeedbackForm, FeedbackData } from '@/components/feedback/FeedbackForm';
-import { Loader2, X, ChevronLeft, ChevronRight, AlertTriangle, RefreshCw, BookOpen } from 'lucide-react';
+import { Loader2, X, ChevronLeft, ChevronRight, AlertTriangle, RefreshCw, BookOpen, CircleHelp, Presentation } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import axios from 'axios';
 import { LessonContext } from '@/hooks/useAudioStreaming';
 import { vizReducer, initialVizState, Visualization } from '@/reducers/visualizationReducer';
+import type { ObjectiveLearningController } from '@/hooks/useObjectiveLearning';
+import { normalizeRequestedArtifactKind } from '@/lib/lesson-artifacts/objective-learning-controller';
+import { LearningArtifactCard } from '@/components/students/study-companion/LearningArtifactCard';
 
 const Editor = dynamic(() => import('@/components/lessons/CodeEditor').then(mod => mod.CodeEditor), { ssr: false });
 const ReactRenderer = dynamic(() => import('@/components/lessons/ReactRenderer').then(mod => mod.ReactRenderer), { ssr: false });
@@ -33,6 +36,7 @@ export type TutorExperienceProps = {
   debugMode: boolean;
   initialTopic: string | null;
   lessonContext?: LessonContext;
+  objectiveLearning?: ObjectiveLearningController;
   onSessionStarted?: (sessionId: string) => void;
   onSessionEnded?: (sessionId: string | null) => void;
 };
@@ -44,6 +48,7 @@ export const TutorExperience = ({
   debugMode,
   initialTopic,
   lessonContext,
+  objectiveLearning,
   onSessionStarted,
   onSessionEnded,
 }: TutorExperienceProps) => {
@@ -192,6 +197,10 @@ export const TutorExperience = ({
   };
 
   const handleRegenerateVisualization = useCallback(async (isManualTrigger = true) => {
+    if (objectiveLearning?.runId) {
+      await objectiveLearning.requestArtifact('visualization', `manual:${objectiveLearning.runId}:${crypto.randomUUID()}`);
+      return;
+    }
     // Reset retry counter when manually triggered
     if (isManualTrigger) {
       regenerationAttemptsRef.current = 0;
@@ -238,7 +247,7 @@ export const TutorExperience = ({
     } finally {
       vizDispatch({ type: 'SET_GENERATING', payload: false });
     }
-  }, [currentVizIndex, visualizations, apiKey, theme, themeColors])
+  }, [currentVizIndex, visualizations, apiKey, theme, themeColors, objectiveLearning])
 
   const handleRendererError = useCallback(async (errMsg: string) => {
     // Increment retry counter
@@ -284,7 +293,22 @@ export const TutorExperience = ({
 
   const handleEditorSubmit = useCallback(() => { }, []);
 
-  const handleToolCall = async (name: string, args: any) => {
+  const handleToolCall = async (name: string, args: any, callId?: string) => {
+    if (name === 'request_learning_artifact' && objectiveLearning?.runId) {
+      try {
+        const kind = normalizeRequestedArtifactKind(args?.kind);
+        const requestId = callId
+          ? `voice:${objectiveLearning.runId}:${callId}`
+          : `voice:${objectiveLearning.runId}:${crypto.randomUUID()}`;
+        const taskDescription = typeof args?.taskDescription === 'string'
+          ? args.taskDescription
+          : typeof args?.task_description === 'string' ? args.task_description : undefined;
+        await objectiveLearning.requestArtifact(kind, requestId, taskDescription);
+      } catch (artifactError) {
+        setError(artifactError instanceof Error ? artifactError.message : 'The learning activity could not be prepared');
+      }
+      return;
+    }
     if (name === 'generate_visualization_description') {
       vizDispatch({ type: 'SET_GENERATING', payload: true });
       try {
@@ -682,6 +706,11 @@ export const TutorExperience = ({
               {lessonContext.subject} {lessonContext.gradeLevel && `• ${lessonContext.gradeLevel}`}
             </p>
           )}
+          {lessonContext?.activeObjective && (
+            <p className="mt-1 max-w-sm line-clamp-2 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+              Objective {lessonContext.activeObjective.position + 1}: {lessonContext.activeObjective.text}
+            </p>
+          )}
         </div>
       </div>
     </div>
@@ -699,6 +728,20 @@ export const TutorExperience = ({
       </div>
     </div>
   );
+
+  const currentObjectiveArtifact = objectiveLearning?.artifacts.at(-1);
+  const preparingActivity = generatingVisualization || Boolean(objectiveLearning?.activityLoading);
+  const activityError = objectiveLearning?.error || error;
+  const objectiveActivityControls = objectiveLearning?.runId ? (
+    <div className="flex flex-wrap items-center justify-center gap-2">
+      <Button size="sm" variant="outline" disabled={objectiveLearning.activityLoading} onClick={() => void objectiveLearning.requestArtifact('visualization').catch(() => {})}>
+        <Presentation className="mr-2 h-4 w-4" /> Show next visual
+      </Button>
+      <Button size="sm" variant="outline" disabled={objectiveLearning.activityLoading} onClick={() => void objectiveLearning.requestArtifact('quiz').catch(() => {})}>
+        <CircleHelp className="mr-2 h-4 w-4" /> Start knowledge check
+      </Button>
+    </div>
+  ) : null;
 
   return (
     <div className="flex h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 dark:from-slate-900 dark:via-slate-800 dark:to-slate-700 relative overflow-hidden">
@@ -729,7 +772,24 @@ export const TutorExperience = ({
         </div>
       )}
       <div className="flex-1 flex flex-col ml-0 lg:min-w-0 overflow-y-auto" ref={vizRef}>
-        {code && library ? (
+        {currentObjectiveArtifact ? (
+          <Card className="flex-1 overflow-y-auto rounded-none border-0 bg-background/95 shadow-none">
+            <CardHeader className="sticky top-0 z-10 border-b bg-background/90 backdrop-blur">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <CardTitle className="text-base">Objective activity</CardTitle>
+                  <p className="mt-1 text-xs text-muted-foreground">Prepared for {lessonContext?.activeObjective?.text}</p>
+                </div>
+                {objectiveActivityControls}
+              </div>
+            </CardHeader>
+            <CardContent className="mx-auto w-full max-w-5xl p-6 pb-28">
+              {objectiveLearning?.activityLoading && <div className="mb-4 flex items-center gap-2 rounded-xl border bg-muted/50 p-3 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" />Preparing activity...</div>}
+              {activityError && <div role="alert" className="mb-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200">{activityError}</div>}
+              <LearningArtifactCard attachment={currentObjectiveArtifact} />
+            </CardContent>
+          </Card>
+        ) : code && library ? (
           <Card className="flex-1 flex flex-col bg-background/95 border-0 shadow-none rounded-none">
             <CardHeader>
               <div className="absolute left-0 px-8 w-full z-10 flex items-center justify-end">
@@ -767,7 +827,7 @@ export const TutorExperience = ({
             </CardHeader>
             <CardContent className="flex-1 flex flex-col p-0 relative">
               <div className="flex-1 p-6 space-y-4">
-                {!generatingVisualization && (
+                {!preparingActivity && (
                   <div
                     ref={vizOnlyRef}
                     className="h-full w-full flex justify-center items-center"
@@ -776,7 +836,7 @@ export const TutorExperience = ({
                     {renderVisualization}
                   </div>
                 )}
-                {!generatingVisualization && (
+                {!preparingActivity && (
                   <div
                     className="h-full"
                     style={{ display: show === 'code' ? 'block' : 'none' }}
@@ -787,11 +847,11 @@ export const TutorExperience = ({
                     />
                   </div>
                 )}
-                {generatingVisualization && (
+                {preparingActivity && (
                   <div className="h-full flex flex-col items-center justify-center">
                     <Loader2 className="w-10 h-10 animate-spin mr-2" />
                     <div className="text-center text-muted-foreground">
-                      <div className="text-lg mb-2">Generating visualization...</div>
+                      <div className="text-lg mb-2">Preparing activity...</div>
                     </div>
                   </div>
                 )}
@@ -799,7 +859,7 @@ export const TutorExperience = ({
             </CardContent>
           </Card>
         ) : (
-          generatingVisualization ? (
+          preparingActivity ? (
             <Card className="flex-1 flex flex-col bg-background/95 border-0 shadow-none rounded-none">
               <CardHeader>
                 {emptyStateHeader}
@@ -807,7 +867,7 @@ export const TutorExperience = ({
               <CardContent className="flex-1 flex flex-col items-center justify-center">
                 <Loader2 className="w-10 h-10 animate-spin mr-2" />
                 <div className="text-center text-muted-foreground">
-                  <div className="text-lg mb-2">Generating visualization...</div>
+                  <div className="text-lg mb-2">Preparing activity...</div>
                 </div>
               </CardContent>
             </Card>
@@ -818,8 +878,10 @@ export const TutorExperience = ({
               </CardHeader>
               <CardContent className="flex-1 flex items-center justify-center">
                 <div className="text-center text-muted-foreground">
-                  <div className="text-lg mb-2">No visualization yet</div>
-                  <div className="text-sm">Ask a question to generate a visualization, quiz, or interactive component</div>
+                  {activityError && <div role="alert" className="mb-5 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200">{activityError}</div>}
+                  <div className="text-lg mb-2">Ready for this objective</div>
+                  <div className="mb-5 text-sm">Ask the tutor, open a reviewed visual, or start a knowledge check.</div>
+                  {objectiveActivityControls}
                 </div>
               </CardContent>
             </Card>

--- a/src/components/lessons/ReactRenderer.tsx
+++ b/src/components/lessons/ReactRenderer.tsx
@@ -135,7 +135,7 @@ export const ReactRenderer: React.FC<ReactRendererProps> = React.memo(({ code, o
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'nonce-${nonce}' 'unsafe-eval' https://unpkg.com https://cdn.jsdelivr.net https://esm.sh https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline' https://unpkg.com https://cdn.tailwindcss.com; style-src-elem 'self' 'unsafe-inline' https://unpkg.com https://cdn.tailwindcss.com; img-src * data: https://images.unsplash.com; font-src https://unpkg.com; connect-src https://cdn.jsdelivr.net https://esm.sh;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'nonce-${nonce}' 'unsafe-eval' https://unpkg.com https://cdn.jsdelivr.net https://esm.sh; style-src 'self' 'unsafe-inline' https://unpkg.com; style-src-elem 'self' 'unsafe-inline' https://unpkg.com; img-src * data: https://images.unsplash.com; font-src https://unpkg.com; connect-src https://cdn.jsdelivr.net https://esm.sh;">
   ${needsLeaflet ? '<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />' : '<!-- Leaflet CSS skipped - not needed -->'}
   <script nonce="${nonce}">
     window.__lessonRenderFailed = false;
@@ -246,27 +246,6 @@ export const ReactRenderer: React.FC<ReactRendererProps> = React.memo(({ code, o
     (function() {
       const needsRecharts = ${needsRecharts ? 'true' : 'false'};
       const needsLeaflet = ${needsLeaflet ? 'true' : 'false'};
-      function loadOptionalTailwind() {
-        if (document.querySelector('script[data-lesson-tailwind]')) return;
-        const tailwindScript = document.createElement('script');
-        tailwindScript.src = 'https://cdn.tailwindcss.com';
-        tailwindScript.async = true;
-        tailwindScript.dataset.lessonTailwind = 'true';
-        tailwindScript.addEventListener('load', function () {
-          if (!window.tailwind) return;
-          window.tailwind.config = {
-            theme: {
-              extend: {
-                colors: {
-                  primary: '#3b82f6',
-                  secondary: '#6b7280'
-                }
-              }
-            }
-          };
-        });
-        document.head.appendChild(tailwindScript);
-      }
       // Wait for React and ReactDOM to load
       function waitForReact(callback, maxAttempts = 100) {
         if (window.React && window.ReactDOM && window.reactLoaded && window.reactDOMLoaded) {
@@ -655,7 +634,6 @@ export const ReactRenderer: React.FC<ReactRendererProps> = React.memo(({ code, o
           setTimeout(function () {
             if (!window.__lessonRenderFailed && window.parent !== window) {
               window.parent.postMessage({ type: 'react-render-ready' }, '*');
-              setTimeout(loadOptionalTailwind, 0);
             }
           }, 0);
         } catch (err) {

--- a/src/components/providers/SupabaseAuthProvider.tsx
+++ b/src/components/providers/SupabaseAuthProvider.tsx
@@ -4,6 +4,7 @@ import { createBrowserClient } from '@supabase/ssr';
 import { createContext, useEffect, useMemo, useRef, useState } from 'react';
 import axios from 'axios';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { shouldClearInvalidRefreshSession } from '@/lib/auth-session';
 
 interface Props {
   children: React.ReactNode;
@@ -43,7 +44,15 @@ export function SupabaseAuthProvider({ children }: Props) {
 
   useEffect(() => {
     let mounted = true;
-    supabase.auth.getSession().then(async ({ data }) => {
+    supabase.auth.getSession().then(async ({ data, error }) => {
+      if (error && shouldClearInvalidRefreshSession(error)) {
+        await supabase.auth.signOut({ scope: 'local' }).catch(() => {});
+        if (mounted) setSession(null);
+        if (window.location.pathname !== '/login') {
+          window.location.replace('/login?reason=session-expired');
+        }
+        return;
+      }
       if (mounted) setSession(data.session);
     });
     const { data: sub } = supabase.auth.onAuthStateChange(async (_event, sess) => {

--- a/src/components/students/study-companion/StudyCompanionShell.tsx
+++ b/src/components/students/study-companion/StudyCompanionShell.tsx
@@ -9,6 +9,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useToast } from '@/components/ui/use-toast';
 import type { LessonContext } from '@/hooks/useAudioStreaming';
+import { useObjectiveLearning } from '@/hooks/useObjectiveLearning';
+import { useStudentProfile } from '@/hooks/useStudentProfile';
 import { requestVisualizationFromGenAi } from '@/lib/request-visualization';
 import {
   MAX_EXPLANATION_LENGTH,
@@ -65,9 +67,6 @@ export function StudyCompanionShell() {
   const [gradeLevel, setGradeLevel] = useState<string | null>(null);
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [selectedLesson, setSelectedLesson] = useState<string | null>(null);
-  const [learningRunId, setLearningRunId] = useState<string | null>(null);
-  const [learningObjectives, setLearningObjectives] = useState<Array<{ id: string; text: string; position: number }>>([]);
-  const [activeObjectiveId, setActiveObjectiveId] = useState<string | null>(null);
   const [currentChatId, setCurrentChatId] = useState<string | null>(null);
   const [mode, setMode] = useState<StudyMode>('companion');
   const [intent, setIntent] = useState<StudyIntent>('general');
@@ -81,6 +80,12 @@ export function StudyCompanionShell() {
   const openPanelButtonRef = useRef<HTMLButtonElement>(null);
   const closePanelButtonRef = useRef<HTMLButtonElement>(null);
   const contextPanelToggledRef = useRef(false);
+  const objectiveLearning = useObjectiveLearning({ lessonId: selectedLesson, mode: 'tutor' });
+  const { data: studentProfile } = useStudentProfile(session?.user?.id);
+
+  useEffect(() => {
+    setGradeLevel(studentProfile?.gradeLevel ?? null);
+  }, [studentProfile?.gradeLevel]);
 
   useEffect(() => {
     chatIdRef.current = currentChatId;
@@ -138,17 +143,10 @@ export function StudyCompanionShell() {
 
   useEffect(() => {
     const fetchStudentContext = async () => {
-      const [profileResult, lessonsResult] = await Promise.allSettled([
-        fetch('/api/students/profile'),
-        fetch('/api/students/lessons'),
-      ]);
-
-      if (profileResult.status === 'fulfilled' && profileResult.value.ok) {
-        const profile = await profileResult.value.json();
-        setGradeLevel(profile.gradeLevel);
-      } else {
-        console.warn('Study companion loaded without a student grade level.');
-      }
+      const lessonsResult = await fetch('/api/students/lessons').then(
+        (value) => ({ status: 'fulfilled' as const, value }),
+        (reason) => ({ status: 'rejected' as const, reason }),
+      );
 
       if (lessonsResult.status === 'fulfilled' && lessonsResult.value.ok) {
         const studentLessons = await lessonsResult.value.json();
@@ -327,9 +325,6 @@ export function StudyCompanionShell() {
     const title = lesson ? `Study session: ${lesson.title}` : 'General study session';
 
     setSelectedLesson(lessonId || null);
-    setLearningRunId(null);
-    setLearningObjectives([]);
-    setActiveObjectiveId(null);
     setCurrentChatId(null);
     chatIdRef.current = null;
     setMode('companion');
@@ -354,18 +349,6 @@ export function StudyCompanionShell() {
       setCurrentChatId(chatId);
       setMessages([initialMessage]);
       updateHistoryTimestamp(chatId, title, lessonId);
-      if (lessonId) {
-        const runResponse = await fetch('/api/learning-runs', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ lessonId, mode: 'tutor' }),
-        });
-        if (runResponse.ok) {
-          const runData = await runResponse.json();
-          setLearningRunId(runData.run.id);
-          setLearningObjectives(runData.objectives);
-          setActiveObjectiveId(runData.run.active_objective_id);
-        }
-      }
       return chatId;
     } catch (error) {
       console.error('Error creating study session:', error);
@@ -389,27 +372,12 @@ export function StudyCompanionShell() {
 
       setMessages(loadedMessages);
       setSelectedLesson(chat.lessonId || null);
-      setLearningRunId(null);
-      setLearningObjectives([]);
-      setActiveObjectiveId(null);
       const loadedChatId = chat._id ?? chat.id ?? null;
       chatIdRef.current = loadedChatId;
       setCurrentChatId(loadedChatId);
       setMode(lastAssistant?.mode ?? 'companion');
       setIntent(lastAssistant?.intent ?? 'general');
       setOutageNotice(null);
-      if (chat.lessonId) {
-        const runResponse = await fetch('/api/learning-runs', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ lessonId: chat.lessonId, mode: 'tutor' }),
-        });
-        if (runResponse.ok) {
-          const runData = await runResponse.json();
-          setLearningRunId(runData.run.id);
-          setLearningObjectives(runData.objectives);
-          setActiveObjectiveId(runData.run.active_objective_id);
-        }
-      }
     } catch (error) {
       console.error('Error loading study session:', error);
       toast({
@@ -432,9 +400,6 @@ export function StudyCompanionShell() {
         setCurrentChatId(null);
         chatIdRef.current = null;
         setSelectedLesson(null);
-        setLearningRunId(null);
-        setLearningObjectives([]);
-        setActiveObjectiveId(null);
         setMode('companion');
         setIntent('general');
         setOutageNotice(null);
@@ -495,7 +460,7 @@ export function StudyCompanionShell() {
           chatId: currentChatId,
           mode: requestMode,
           intent: requestIntent,
-          learningRunId,
+          learningRunId: objectiveLearning.runId,
         }),
       });
 
@@ -783,15 +748,9 @@ export function StudyCompanionShell() {
                   selectedLesson={selectedLesson}
                   disabled={isLoading}
                   onLessonChange={startNewChat}
-                  objectives={learningObjectives}
-                  selectedObjectiveId={activeObjectiveId}
-                  onObjectiveChange={async (objectiveId) => {
-                    if (!learningRunId) return;
-                    const response = await fetch(`/api/learning-runs/${learningRunId}/objective`, {
-                      method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ objectiveId }),
-                    });
-                    if (response.ok) setActiveObjectiveId(objectiveId);
-                  }}
+                  objectives={objectiveLearning.objectives}
+                  selectedObjectiveId={objectiveLearning.activeObjective?.id}
+                  onObjectiveChange={objectiveLearning.selectObjective}
                 />
               </div>
               <ChatHistoryPanel

--- a/src/components/students/study-companion/types.ts
+++ b/src/components/students/study-companion/types.ts
@@ -1,3 +1,5 @@
+import type { ObjectiveLearningArtifact } from '@/lib/lesson-artifacts/objective-learning-controller';
+
 export type StudyMode = 'companion' | 'tutor';
 
 export type StudyIntent = 'general' | 'plan' | 'hint' | 'explain' | 'quiz' | 'review' | 'walkthrough';
@@ -20,16 +22,7 @@ export interface SuggestedAction {
   prompt: string;
 }
 
-export interface LearningArtifactAttachment {
-  instanceId: string;
-  source: 'teacher_approved' | 'session_generated';
-  exhausted: boolean;
-  artifact: {
-    id: string;
-    kind: 'interactive_visualization' | 'generated_image' | 'structured_quiz' | 'visual_quiz' | 'uploaded_media';
-    payload: any;
-  } & Record<string, unknown>;
-}
+export type LearningArtifactAttachment = ObjectiveLearningArtifact;
 
 /** Payload emitted when an interactive element is regenerated in place. */
 export interface InteractiveElementUpdate {

--- a/src/components/voice/VoiceControl.tsx
+++ b/src/components/voice/VoiceControl.tsx
@@ -10,7 +10,7 @@ interface VoiceControlProps {
   topic?: string | null;
   lessonContext?: LessonContext;
   onError?: (error: string) => void;
-  onToolCall?: (name: string, args: any) => void;
+  onToolCall?: (name: string, args: any, callId?: string) => void;
   onConnectionStatusChange?: (status: 'disconnected' | 'connecting' | 'connected') => void;
   onCountdownEnd?: () => void;
   mobileMode?: boolean;
@@ -218,4 +218,4 @@ export function VoiceControl({ active, sessionId, topic, lessonContext, onError,
       </div>
     </div>
   );
-} 
+}

--- a/src/hooks/useAudioStreaming.ts
+++ b/src/hooks/useAudioStreaming.ts
@@ -4,6 +4,7 @@ import { buildStudyCompanionLiveVoiceSystemPrompt, type StudyIntent, type StudyM
 import { EUREKA_TUTOR_SYSTEM_PROMPT } from '@/lib/tutor-system-prompt';
 import { extractServerTranscriptions, mergeStreamingTranscript } from '@/lib/audio/transcription';
 import { convertToWav } from '@/lib/audio/wav';
+import { buildObjectiveTutorPromptContext } from '@/lib/lesson-artifacts/objective-learning-controller';
 
 export type UseAudioStreamingLiveOptions = {
     variant?: 'tutor' | 'studyCompanion';
@@ -32,7 +33,7 @@ interface AudioStreamingActions {
     startStreaming: () => Promise<void>;
     stopStreaming: () => void;
     clearError: () => void;
-    setToolCallListener: (cb: (name: string, args: any) => void) => void;
+    setToolCallListener: (cb: (name: string, args: any, callId?: string) => void) => void;
     setOnAudioDataListener: (cb: (data: Float32Array<ArrayBufferLike>) => void) => void;
     setOnAiAudioDataListener: (cb: (data: Float32Array) => void) => void;
     setOnRecordingsReady: (cb: (payload: { user: Blob | null; ai: Blob | null; durationMs: number }) => void) => void;
@@ -54,8 +55,10 @@ export interface LessonContext {
     title?: string;
     subject?: string;
     gradeLevel?: string;
-    objectives?: string;
+    objectives?: string | string[];
     content?: string;
+    learningRunId?: string;
+    activeObjective?: { id: string; text: string; position: number; revision: number };
 }
 
 const systemPrompt = EUREKA_TUTOR_SYSTEM_PROMPT;
@@ -83,7 +86,7 @@ export function useAudioStreaming(
     const nextPlaybackTimeRef = useRef<number>(0);
     const analyserRef = useRef<AnalyserNode | null>(null);
     const micAnalyserRef = useRef<AnalyserNode | null>(null);
-    const toolCallListenerRef = useRef<((name: string, args: any) => void) | null>(null);
+    const toolCallListenerRef = useRef<((name: string, args: any, callId?: string) => void) | null>(null);
     const onAudioDataListenerRef = useRef<((data: Float32Array<ArrayBufferLike>) => void) | null>(null);
     const onAiAudioDataListenerRef = useRef<((data: Float32Array) => void) | null>(null);
     const onRecordingsReadyRef = useRef<((payload: { user: Blob | null; ai: Blob | null; durationMs: number }) => void) | null>(null);
@@ -467,7 +470,18 @@ export function useAudioStreaming(
             const lessonCtx = lessonContextRef.current;
             const topicNow = topicRef.current;
 
-            if (lessonCtx?.title) {
+            if (lessonCtx?.title && lessonCtx.learningRunId && lessonCtx.activeObjective) {
+                contextAddition = `\n\n${buildObjectiveTutorPromptContext({
+                    lessonTitle: lessonCtx.title,
+                    subject: lessonCtx.subject,
+                    gradeLevel: lessonCtx.gradeLevel,
+                    objectiveText: lessonCtx.activeObjective.text,
+                    lessonContent: lessonCtx.content,
+                })}`;
+            } else if (lessonCtx?.title) {
+                const objectiveText = Array.isArray(lessonCtx.objectives)
+                    ? lessonCtx.objectives.map((objective) => `- ${objective}`).join('\n')
+                    : lessonCtx.objectives;
                 contextAddition = `
 
 ### **Lesson Context**
@@ -478,7 +492,7 @@ You are helping a student learn material from a specific lesson:
 - **Grade Level:** ${lessonCtx.gradeLevel || 'Not specified'}
 
 **Learning Objectives:**
-${lessonCtx.objectives || 'No specific objectives provided.'}
+${objectiveText || 'No specific objectives provided.'}
 
 **Lesson Content:**
 ${lessonCtx.content ? lessonCtx.content.substring(0, 2000) + (lessonCtx.content.length > 2000 ? '...' : '') : 'No content provided.'}
@@ -502,7 +516,9 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
                         ? {
                             title: lessonCtx.title,
                             subject: lessonCtx.subject || 'general',
-                            objectives: lessonCtx.objectives ?? null,
+                            objectives: Array.isArray(lessonCtx.objectives)
+                                ? lessonCtx.objectives.join('\n')
+                                : lessonCtx.objectives ?? null,
                             content: lessonCtx.content ?? null,
                         }
                         : undefined;
@@ -528,11 +544,24 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
                 },
             };
 
+            const objectiveArtifactToolDeclaration = {
+                name: 'request_learning_artifact',
+                description: 'Shows the next teacher-reviewed visualization or quiz for the active objective, generating a fallback only after reviewed activities are exhausted.',
+                parameters: {
+                    type: 'object',
+                    properties: {
+                        kind: { type: 'string', enum: ['visualization', 'quiz'] },
+                        taskDescription: { type: 'string', description: 'A short description of the concept or check the learner needs.' },
+                    },
+                    required: ['kind', 'taskDescription'],
+                },
+            };
+
             const tutorTools = [
                 { googleSearch: {} },
                 {
                     functionDeclarations: [
-                        visualizationToolDeclaration,
+                        lessonCtx?.learningRunId ? objectiveArtifactToolDeclaration : visualizationToolDeclaration,
                         {
                             name: 'set_topic',
                             description:
@@ -960,7 +989,7 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
                 // Handle tool calls
                 if (message?.toolCall?.functionCalls && message.toolCall.functionCalls.length > 0) {
                     for (const fn of message.toolCall.functionCalls) {
-                        toolCallListenerRef.current?.(fn.name || '', fn.args);
+                        toolCallListenerRef.current?.(fn.name || '', fn.args, fn.id || undefined);
 
                         // Send response back to Gemini
                         try {
@@ -1134,7 +1163,7 @@ Focus your teaching on these objectives. Use the lesson material as the foundati
 
     // PCM→WAV conversion lives in '@/lib/audio/wav' (pure, unit-tested).
 
-    const setToolCallListener = useCallback((cb: (name: string, args: any) => void) => {
+    const setToolCallListener = useCallback((cb: (name: string, args: any, callId?: string) => void) => {
         toolCallListenerRef.current = cb;
     }, []);
 

--- a/src/hooks/useObjectiveLearning.ts
+++ b/src/hooks/useObjectiveLearning.ts
@@ -1,0 +1,157 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  appendUniqueArtifact,
+  createAsyncRequestDeduper,
+  createLearningScopeGuard,
+  type ObjectiveLearningArtifact,
+} from '@/lib/lesson-artifacts/objective-learning-controller';
+
+export type LearningObjective = {
+  id: string;
+  text: string;
+  position: number;
+  revision: number;
+};
+
+type LearningRun = {
+  id: string;
+  active_objective_id: string;
+};
+
+async function readJson(response: Response) {
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(data.error || 'The objective learning session could not be loaded');
+  return data;
+}
+
+export function useObjectiveLearning(options: {
+  lessonId?: string | null;
+  objectiveId?: string | null;
+  mode?: 'companion' | 'tutor';
+  autoStart?: boolean;
+}) {
+  const { lessonId, objectiveId, mode = 'tutor', autoStart = true } = options;
+  const [run, setRun] = useState<LearningRun | null>(null);
+  const [runScope, setRunScope] = useState<string | null>(null);
+  const [objectives, setObjectives] = useState<LearningObjective[]>([]);
+  const [artifacts, setArtifacts] = useState<ObjectiveLearningArtifact[]>([]);
+  const [loading, setLoading] = useState(Boolean(lessonId && autoStart));
+  const [activityLoading, setActivityLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const deduperRef = useRef(createAsyncRequestDeduper());
+  const scopeGuardRef = useRef(createLearningScopeGuard());
+  const scope = lessonId ? `${lessonId}:${mode}` : null;
+  const scopedRun = runScope === scope ? run : null;
+
+  const initialize = useCallback(async (requestedObjectiveId?: string | null) => {
+    if (!lessonId) return null;
+    const requestScope = `${lessonId}:${mode}`;
+    const token = scopeGuardRef.current.begin(requestScope);
+    setLoading(true);
+    setError(null);
+    try {
+      const key = `run:${lessonId}:${mode}:${requestedObjectiveId ?? ''}`;
+      const data = await deduperRef.current.run(key, async () => readJson(await fetch('/api/learning-runs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lessonId, mode, ...(requestedObjectiveId ? { objectiveId: requestedObjectiveId } : {}) }),
+      })));
+      if (!scopeGuardRef.current.isCurrent(token)) return null;
+      setRun(data.run);
+      setRunScope(requestScope);
+      setObjectives(data.objectives ?? []);
+      setArtifacts([]);
+      return data.run as LearningRun;
+    } catch (requestError) {
+      if (scopeGuardRef.current.isCurrent(token)) {
+        setRun(null);
+        setRunScope(requestScope);
+        setObjectives([]);
+        setArtifacts([]);
+        setError(requestError instanceof Error ? requestError.message : 'The objective learning session could not be loaded');
+      }
+      return null;
+    } finally {
+      if (scopeGuardRef.current.isCurrent(token)) setLoading(false);
+    }
+  }, [lessonId, mode]);
+
+  useEffect(() => {
+    scopeGuardRef.current.clear();
+    if (!autoStart || !lessonId) return;
+    const timeoutId = window.setTimeout(() => { void initialize(objectiveId); }, 0);
+    return () => window.clearTimeout(timeoutId);
+  }, [autoStart, initialize, lessonId, mode, objectiveId]);
+
+  const selectObjective = useCallback(async (nextObjectiveId: string) => {
+    if (!scopedRun) return false;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await readJson(await fetch(`/api/learning-runs/${scopedRun.id}/objective`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ objectiveId: nextObjectiveId }),
+      }));
+      setRun(data.run);
+      setArtifacts([]);
+      return true;
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : 'The objective could not be selected');
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [scopedRun]);
+
+  const requestArtifact = useCallback(async (
+    kind: 'visualization' | 'quiz',
+    requestId = crypto.randomUUID(),
+    taskDescription?: string,
+  ) => {
+    if (!scopedRun) throw new Error('The objective learning session is not ready');
+    setActivityLoading(true);
+    setError(null);
+    try {
+      const attachment = await deduperRef.current.run(`artifact:${scopedRun.id}:${requestId}`, async () => readJson(await fetch(
+        `/api/learning-runs/${scopedRun.id}/artifacts/next`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ kind, requestId, ...(taskDescription?.trim() ? { taskDescription: taskDescription.trim() } : {}) }),
+        },
+      ))) as ObjectiveLearningArtifact;
+      setArtifacts((current) => appendUniqueArtifact(current, attachment));
+      return attachment;
+    } catch (requestError) {
+      const message = requestError instanceof Error ? requestError.message : 'The learning activity could not be prepared';
+      setError(message);
+      throw requestError;
+    } finally {
+      setActivityLoading(false);
+    }
+  }, [scopedRun]);
+
+  const activeObjective = useMemo(
+    () => objectives.find((objective) => objective.id === scopedRun?.active_objective_id) ?? null,
+    [objectives, scopedRun?.active_objective_id],
+  );
+
+  return {
+    runId: scopedRun?.id ?? null,
+    objectives: scopedRun ? objectives : [],
+    activeObjective,
+    artifacts: scopedRun ? artifacts : [],
+    loading: Boolean(autoStart && scope && runScope !== scope) || loading,
+    activityLoading: scopedRun ? activityLoading : false,
+    error: runScope === scope ? error : null,
+    initialize,
+    selectObjective,
+    requestArtifact,
+  };
+}
+
+export type ObjectiveLearningController = ReturnType<typeof useObjectiveLearning>;

--- a/src/hooks/useStudentProfile.ts
+++ b/src/hooks/useStudentProfile.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { studentProfileQueryKey, type StudentProfile } from '@/lib/student-profile';
+
+export function useStudentProfile(userId?: string | null) {
+  return useQuery<StudentProfile>({
+    queryKey: studentProfileQueryKey(userId),
+    enabled: Boolean(userId),
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const response = await fetch('/api/students/profile');
+      if (!response.ok) throw new Error('Failed to load student profile');
+      return response.json();
+    },
+  });
+}

--- a/src/lib/__tests__/auth-session.test.ts
+++ b/src/lib/__tests__/auth-session.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldClearInvalidRefreshSession } from '../auth-session';
+
+describe('browser auth session recovery', () => {
+  it('clears only invalid or missing refresh-token failures', () => {
+    expect(shouldClearInvalidRefreshSession(new Error('Invalid Refresh Token: Refresh Token Not Found'))).toBe(true);
+    expect(shouldClearInvalidRefreshSession({ message: 'refresh_token_not_found' })).toBe(true);
+    expect(shouldClearInvalidRefreshSession(new Error('Network request failed'))).toBe(false);
+  });
+});

--- a/src/lib/__tests__/student-profile.test.ts
+++ b/src/lib/__tests__/student-profile.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveStudentDisplayName, studentProfileQueryKey } from '../student-profile';
+
+describe('student profile display name', () => {
+  it('prefers the application profile and falls back through auth metadata and email', () => {
+    expect(resolveStudentDisplayName({ profileName: 'Ada Lovelace', metadataName: 'Ada', email: 'ada@example.com' })).toBe('Ada Lovelace');
+    expect(resolveStudentDisplayName({ profileName: ' ', metadataName: 'Grace', email: 'grace@example.com' })).toBe('Grace');
+    expect(resolveStudentDisplayName({ email: 'student@test.com' })).toBe('student');
+    expect(resolveStudentDisplayName({})).toBe('there');
+  });
+});
+
+describe('student profile query key', () => {
+  it('isolates cached profiles by authenticated user', () => {
+    expect(studentProfileQueryKey('student-1')).not.toEqual(studentProfileQueryKey('student-2'));
+    expect(studentProfileQueryKey('student-1')).toEqual(['student-profile', 'student-1']);
+  });
+});

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,0 +1,13 @@
+export function shouldClearInvalidRefreshSession(error: unknown): boolean {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === 'object' && error && 'message' in error
+      ? String(error.message)
+      : String(error ?? '');
+  const normalized = message.toLowerCase().replace(/[_-]+/g, ' ');
+  return normalized.includes('refresh token') && (
+    normalized.includes('invalid') ||
+    normalized.includes('not found') ||
+    normalized.includes('missing')
+  );
+}

--- a/src/lib/lesson-artifacts/__tests__/jobs.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/jobs.test.ts
@@ -42,6 +42,23 @@ describe('content job generation', () => {
     });
   });
 
+  it('includes a bounded learner request in session fallback generation prompts', async () => {
+    let visualPrompt = '';
+    await generateArtifactPayload({
+      ...baseJob,
+      input: { ...baseJob.input, taskDescription: 'Compare equal and unequal opposing forces.' },
+    }, {
+      visualize: async (prompt) => {
+        visualPrompt = prompt;
+        return { library: 'react', code: 'function App() {}', explanation: 'Compare forces.' };
+      },
+      generateText: async () => '',
+      generateImage: async () => { throw new Error('not used'); },
+    });
+
+    expect(visualPrompt).toContain('Learner request: Compare equal and unequal opposing forces.');
+  });
+
   it('creates a five-question structured quiz that conforms to the server grading schema', async () => {
     const questions = Array.from({ length: 5 }, (_, index) => ({
       id: `q${index + 1}`,

--- a/src/lib/lesson-artifacts/__tests__/learning-artifact-route.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/learning-artifact-route.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const resolveNextLearningArtifactMock = vi.fn();
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/lesson-artifacts/learning-server', () => ({
+  resolveNextLearningArtifact: resolveNextLearningArtifactMock,
+}));
+vi.mock('@/lib/rate-limiter', () => ({ rateLimit: vi.fn().mockResolvedValue(null) }));
+
+describe('next learning artifact route', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resolveNextLearningArtifactMock.mockResolvedValue({ instanceId: 'instance-1' });
+  });
+
+  it('passes the learner task description to approved-first resolution', async () => {
+    const { POST } = await import('@/app/api/learning-runs/[runId]/artifacts/next/route');
+    const response = await POST(new Request('http://localhost/api/learning-runs/run-1/artifacts/next', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        kind: 'visualization',
+        requestId: 'voice:run-1:call-1',
+        taskDescription: 'Compare balanced and unbalanced forces.',
+      }),
+    }) as never, { params: Promise.resolve({ runId: 'run-1' }) });
+
+    expect(response.status).toBe(200);
+    expect(resolveNextLearningArtifactMock).toHaveBeenCalledWith({
+      runId: 'run-1',
+      kind: 'visualization',
+      requestId: 'voice:run-1:call-1',
+      taskDescription: 'Compare balanced and unbalanced forces.',
+    });
+  });
+});

--- a/src/lib/lesson-artifacts/__tests__/learning-run-route.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/learning-run-route.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requireStudentSessionMock = vi.fn();
+const createServerSupabaseMock = vi.fn();
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/lesson-artifacts/learning-server', () => ({
+  requireStudentSession: requireStudentSessionMock,
+}));
+vi.mock('@/lib/supabase.server', () => ({
+  createServerSupabase: createServerSupabaseMock,
+}));
+
+const lessonId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const objective1 = '11111111-1111-4111-8111-111111111111';
+const objective2 = '22222222-2222-4222-8222-222222222222';
+
+function terminal(result: { data: unknown; error: unknown }, method: 'single' | 'maybeSingle') {
+  return { [method]: vi.fn().mockResolvedValue(result) };
+}
+
+function createHarness(
+  existingRun: Record<string, unknown> | null = null,
+  options: { eventError?: Error } = {},
+) {
+  const insertedRun = {
+    id: 'run-new',
+    active_objective_id: objective1,
+    student_id: 'student-1',
+    lesson_id: lessonId,
+  };
+  const insertRun = vi.fn(() => ({
+    select: vi.fn(() => terminal({ data: insertedRun, error: null }, 'single')),
+  }));
+  const updateRun = vi.fn((values: Record<string, unknown>) => ({
+    eq: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => terminal({ data: { ...(existingRun ?? {}), ...values }, error: null }, 'single')),
+      })),
+    })),
+  }));
+  const insertEvent = vi.fn().mockResolvedValue({ data: null, error: options.eventError ?? null });
+
+  const from = vi.fn((table: string) => {
+    if (table === 'lessons') {
+      return { select: vi.fn(() => ({ eq: vi.fn(() => terminal({ data: {
+        id: lessonId,
+        title: 'Forces',
+        subject: 'Physics',
+        gradelevel: 'JHS 1',
+        current_publication_id: 'publication-1',
+      }, error: null }, 'maybeSingle')) })) };
+    }
+    if (table === 'students') {
+      return { select: vi.fn(() => ({ eq: vi.fn(() => terminal({ data: { grade: 'jhs 1' }, error: null }, 'maybeSingle')) })) };
+    }
+    if (table === 'lesson_publications') {
+      return { select: vi.fn(() => ({ eq: vi.fn(() => terminal({ data: {
+        id: 'publication-1',
+        version: 3,
+        manifest: { objectives: [
+          { id: objective1, text: 'Define force.', position: 0, revision: 1 },
+          { id: objective2, text: 'Calculate force.', position: 1, revision: 2 },
+        ] },
+      }, error: null }, 'single')) })) };
+    }
+    if (table === 'learning_runs') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  eq: vi.fn(() => ({
+                    order: vi.fn(() => ({
+                      limit: vi.fn(() => terminal({ data: existingRun, error: null }, 'maybeSingle')),
+                    })),
+                  })),
+                })),
+              })),
+            })),
+          })),
+        })),
+        insert: insertRun,
+        update: updateRun,
+      };
+    }
+    if (table === 'learning_events') return { insert: insertEvent };
+    throw new Error(`Unexpected table ${table}`);
+  });
+
+  createServerSupabaseMock.mockReturnValue({ from });
+  return { insertRun, updateRun, insertEvent };
+}
+
+async function callPost(body: unknown) {
+  const { POST } = await import('@/app/api/learning-runs/route');
+  const response = await POST(new Request('http://localhost/api/learning-runs', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+  return { response, json: await response.json() };
+}
+
+describe('learning run objective selection', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    requireStudentSessionMock.mockResolvedValue({ user: { id: 'student-1', role: 'student' } });
+  });
+
+  it('creates a run on the requested publication objective', async () => {
+    const harness = createHarness();
+
+    const { response } = await callPost({ lessonId, mode: 'tutor', objectiveId: objective1 });
+
+    expect(response.status).toBe(200);
+    expect(harness.insertRun).toHaveBeenCalledWith(expect.objectContaining({ active_objective_id: objective1 }));
+    expect(harness.insertEvent).not.toHaveBeenCalled();
+  });
+
+  it('switches a resumed run and records one objective_changed event', async () => {
+    const existingRun = { id: 'run-1', active_objective_id: objective1, student_id: 'student-1', lesson_id: lessonId };
+    const harness = createHarness(existingRun);
+
+    const { response } = await callPost({ lessonId, mode: 'tutor', objectiveId: objective2 });
+
+    expect(response.status).toBe(200);
+    expect(harness.updateRun).toHaveBeenCalledWith(expect.objectContaining({ active_objective_id: objective2 }));
+    expect(harness.insertEvent).toHaveBeenCalledOnce();
+    expect(harness.insertEvent).toHaveBeenCalledWith(expect.objectContaining({
+      event_type: 'objective_changed',
+      objective_id: objective2,
+      objective_revision: 2,
+    }));
+  });
+
+  it('rejects a stale objective without creating or updating a run', async () => {
+    const harness = createHarness();
+    const staleObjective = '33333333-3333-4333-8333-333333333333';
+
+    const { response } = await callPost({ lessonId, mode: 'tutor', objectiveId: staleObjective });
+
+    expect(response.status).toBe(400);
+    expect(harness.insertRun).not.toHaveBeenCalled();
+    expect(harness.updateRun).not.toHaveBeenCalled();
+  });
+
+  it('restores the previous objective if objective_changed recording fails', async () => {
+    const existingRun = { id: 'run-1', active_objective_id: objective1, student_id: 'student-1', lesson_id: lessonId };
+    const harness = createHarness(existingRun, { eventError: new Error('event insert failed') });
+
+    const { response } = await callPost({ lessonId, mode: 'tutor', objectiveId: objective2 });
+
+    expect(response.status).toBe(500);
+    expect(harness.updateRun).toHaveBeenCalledTimes(2);
+    expect(harness.updateRun).toHaveBeenNthCalledWith(2, expect.objectContaining({ active_objective_id: objective1 }));
+  });
+});

--- a/src/lib/lesson-artifacts/__tests__/objective-learning-controller.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/objective-learning-controller.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendUniqueArtifact,
+  buildObjectiveTutorPromptContext,
+  createAsyncRequestDeduper,
+  createLearningScopeGuard,
+  normalizeRequestedArtifactKind,
+} from '../objective-learning-controller';
+
+describe('objective learning controller', () => {
+  it('shares an in-flight request with duplicate callers and releases it after completion', async () => {
+    const deduper = createAsyncRequestDeduper();
+    let calls = 0;
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    const operation = async () => {
+      calls += 1;
+      await pending;
+      return { value: calls };
+    };
+
+    const first = deduper.run('artifact-call-1', operation);
+    const duplicate = deduper.run('artifact-call-1', operation);
+    expect(duplicate).toBe(first);
+    expect(calls).toBe(1);
+
+    release();
+    await expect(first).resolves.toEqual({ value: 1 });
+    await deduper.run('artifact-call-1', operation);
+    expect(calls).toBe(2);
+  });
+
+  it('does not append the same resolved artifact instance twice', () => {
+    const artifact = { instanceId: 'instance-1', source: 'teacher_approved' as const };
+    expect(appendUniqueArtifact([artifact], artifact)).toEqual([artifact]);
+    expect(appendUniqueArtifact([], artifact)).toEqual([artifact]);
+  });
+
+  it('invalidates stale learning requests when the lesson scope changes', () => {
+    const guard = createLearningScopeGuard();
+    const firstLesson = guard.begin('lesson-1:tutor');
+    const secondLesson = guard.begin('lesson-2:tutor');
+
+    expect(guard.isCurrent(firstLesson)).toBe(false);
+    expect(guard.isCurrent(secondLesson)).toBe(true);
+    guard.clear();
+    expect(guard.isCurrent(secondLesson)).toBe(false);
+  });
+
+  it('focuses the voice tutor on one objective and names the approved-first tool', () => {
+    const context = buildObjectiveTutorPromptContext({
+      lessonTitle: 'Forces and Motion',
+      subject: 'Physics',
+      gradeLevel: 'JHS 1',
+      objectiveText: 'Calculate the net force acting on an object.',
+    });
+
+    expect(context).toContain('Active objective: Calculate the net force acting on an object.');
+    expect(context).toContain('request_learning_artifact');
+    expect(normalizeRequestedArtifactKind('quiz')).toBe('quiz');
+    expect(normalizeRequestedArtifactKind('diagram')).toBe('visualization');
+  });
+});

--- a/src/lib/lesson-artifacts/__tests__/react-sandbox-runtime.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/react-sandbox-runtime.test.ts
@@ -8,21 +8,25 @@ import {
   REACT_SANDBOX_SOURCES,
   renderReactSandboxScripts,
 } from '../react-sandbox-runtime';
+import { LESSON_RUNTIME_COMPATIBILITY_CLASSES } from '../lesson-runtime-compatibility';
 
 describe('React sandbox runtime', () => {
   it('uses pinned classic scripts with an explicit boot failure', () => {
     expect(REACT_SANDBOX_SOURCES).toEqual({
       react: '/lesson-runtime/react-18.3.1.production.min.js',
       reactDom: '/lesson-runtime/react-dom-18.3.1.production.min.js',
+      tailwindCss: '/lesson-runtime/tailwind.generated.css',
     });
 
     const scripts = renderReactSandboxScripts('nonce-1', {
       react: 'window.React = { version: "18.3.1" };',
       reactDom: 'window.ReactDOM = { createRoot: function () {} };',
+      tailwindCss: '.flex{display:flex}',
     });
     expect(scripts).toContain('nonce="nonce-1"');
     expect(scripts).toContain('window.React');
     expect(scripts).toContain('window.ReactDOM');
+    expect(scripts).toContain('.flex{display:flex}');
     expect(scripts).toContain('Failed to load React runtime');
     expect(scripts).not.toContain('type="module"');
     expect(scripts).not.toContain(' src=');
@@ -31,12 +35,15 @@ describe('React sandbox runtime', () => {
   it('loads pinned runtime text through the trusted parent page', async () => {
     const fetcher = async (input: RequestInfo | URL) => ({
       ok: true,
-      text: async () => String(input).includes('react-dom') ? 'react-dom-source' : 'react-source',
+      text: async () => String(input).includes('tailwind')
+        ? 'tailwind-source'
+        : String(input).includes('react-dom') ? 'react-dom-source' : 'react-source',
     }) as Response;
 
     await expect(fetchReactSandboxSources(fetcher)).resolves.toEqual({
       react: 'react-source',
       reactDom: 'react-dom-source',
+      tailwindCss: 'tailwind-source',
     });
   });
 
@@ -50,17 +57,27 @@ describe('React sandbox runtime', () => {
     expect(renderer).not.toContain('sandbox="allow-scripts allow-same-origin"');
   });
 
-  it('loads optional Tailwind styling only after the component reports ready', async () => {
+  it('uses only the local Tailwind stylesheet in the generated iframe', async () => {
     const renderer = await readFile(
       join(process.cwd(), 'src', 'components', 'lessons', 'ReactRenderer.tsx'),
       'utf8',
     );
 
-    expect(renderer).not.toContain('<script src="https://cdn.tailwindcss.com"');
-    expect(renderer).not.toContain('<script async src="https://cdn.tailwindcss.com"');
-    expect(renderer).toContain('setTimeout(loadOptionalTailwind, 0)');
-    expect(renderer).not.toContain('window.tailwind = window.tailwind || {}');
-    expect(renderer).toContain("tailwindScript.addEventListener('load'");
+    expect(renderer).not.toContain('cdn.tailwindcss.com');
+    expect(renderer).not.toContain('loadOptionalTailwind');
+  });
+
+  it('keeps representative approved-artifact utilities in the bounded runtime', () => {
+    expect(LESSON_RUNTIME_COMPATIBILITY_CLASSES).toEqual(expect.arrayContaining([
+      'grid-cols-2',
+      'md:grid-cols-3',
+      'bg-gradient-to-r',
+      'from-blue-500',
+      'to-purple-500',
+      'w-1/2',
+      'transition-transform',
+      'hover:scale-105',
+    ]));
   });
 
   it('does not wait for an animation frame while the preview iframe is hidden', async () => {

--- a/src/lib/lesson-artifacts/__tests__/student-learning.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/student-learning.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildStudentLessonDetail,
+  isObjectiveSelectionChange,
+  normalizeLegacyObjectives,
+  normalizePublishedObjectives,
+  selectPublishedObjective,
+  summarizePublishedObjectives,
+} from '../student-learning';
+
+describe('student lesson objective contract', () => {
+  it('normalizes arrays, JSON strings, and newline-separated legacy objectives', () => {
+    expect(normalizeLegacyObjectives([' Explain force. ', '', 'Calculate net force.'])).toEqual([
+      'Explain force.',
+      'Calculate net force.',
+    ]);
+    expect(normalizeLegacyObjectives('["Explain force.","Calculate net force."]')).toEqual([
+      'Explain force.',
+      'Calculate net force.',
+    ]);
+    expect(normalizeLegacyObjectives('Explain force.\n\nCalculate net force.')).toEqual([
+      'Explain force.',
+      'Calculate net force.',
+    ]);
+  });
+
+  it('normalizes structured objective arrays and JSON snapshots without trusting malformed legacy data', () => {
+    const objectives = [{
+      id: '11111111-1111-4111-8111-111111111111',
+      text: ' Explain force. ',
+      position: 0,
+      revision: 2,
+      artifactIds: ['visual-1'],
+    }];
+
+    expect(normalizePublishedObjectives(objectives)?.[0]?.text).toBe('Explain force.');
+    expect(normalizePublishedObjectives(JSON.stringify(objectives))).toEqual([
+      { ...objectives[0], text: 'Explain force.' },
+    ]);
+    expect(normalizePublishedObjectives('Explain force.\nCalculate force.')).toBeNull();
+    expect(normalizePublishedObjectives([{ text: 'Missing immutable objective id' }])).toBeNull();
+  });
+
+  it('sorts published objectives and counts only artifacts in each publication snapshot', () => {
+    const result = summarizePublishedObjectives({
+      objectives: [
+        { id: 'objective-2', text: 'Calculate net force.', position: 1, revision: 2, artifactIds: ['quiz-1'] },
+        { id: 'objective-1', text: 'Explain force.', position: 0, revision: 1, artifactIds: ['visual-1', 'image-1', 'missing'] },
+      ],
+      artifacts: [
+        { id: 'visual-1', kind: 'interactive_visualization' },
+        { id: 'image-1', kind: 'generated_image' },
+        { id: 'quiz-1', kind: 'structured_quiz' },
+        { id: 'unpublished-quiz', kind: 'visual_quiz' },
+      ],
+    });
+
+    expect(result).toEqual([
+      {
+        id: 'objective-1',
+        text: 'Explain force.',
+        position: 0,
+        revision: 1,
+        artifactCounts: { visualizations: 2, quizzes: 0, resources: 0 },
+      },
+      {
+        id: 'objective-2',
+        text: 'Calculate net force.',
+        position: 1,
+        revision: 2,
+        artifactCounts: { visualizations: 0, quizzes: 1, resources: 0 },
+      },
+    ]);
+  });
+
+  it('selects the requested published objective or defaults to the first objective', () => {
+    const objectives = [
+      { id: 'objective-2', text: 'Second', position: 1, revision: 1 },
+      { id: 'objective-1', text: 'First', position: 0, revision: 1 },
+    ];
+
+    expect(selectPublishedObjective(objectives, 'objective-2')?.id).toBe('objective-2');
+    expect(selectPublishedObjective(objectives)?.id).toBe('objective-1');
+    expect(selectPublishedObjective(objectives, 'stale-objective')).toBeUndefined();
+  });
+
+  it('records an objective change only when a resumed run switches objectives', () => {
+    expect(isObjectiveSelectionChange(undefined, 'objective-1')).toBe(false);
+    expect(isObjectiveSelectionChange('objective-1', 'objective-1')).toBe(false);
+    expect(isObjectiveSelectionChange('objective-1', 'objective-2')).toBe(true);
+  });
+
+  it('builds lesson details from the immutable publication snapshot', () => {
+    const detail = buildStudentLessonDetail({
+      publicationVersion: 4,
+      manifest: {
+        lesson: {
+          id: 'lesson-1',
+          title: 'Published title',
+          subject: 'Physics',
+          gradeLevel: 'JHS 1',
+          content: 'Published content',
+        },
+        objectives: [
+          { id: 'objective-1', text: 'Explain force.', position: 0, revision: 3, artifactIds: ['visual-1'] },
+        ],
+      },
+      artifacts: [{ id: 'visual-1', kind: 'interactive_visualization' }],
+    });
+
+    expect(detail.lesson.title).toBe('Published title');
+    expect(detail.publicationVersion).toBe(4);
+    expect(detail.objectives[0]?.artifactCounts.visualizations).toBe(1);
+  });
+});

--- a/src/lib/lesson-artifacts/__tests__/student-lesson-content-access.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/student-lesson-content-access.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getServerSessionMock = vi.fn();
+const createServerSupabaseMock = vi.fn();
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/auth', () => ({ getServerSession: getServerSessionMock }));
+vi.mock('@/lib/supabase.server', () => ({ createServerSupabase: createServerSupabaseMock }));
+
+const lessonId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function terminal(data: unknown) {
+  return { maybeSingle: vi.fn().mockResolvedValue({ data, error: null }) };
+}
+
+function createHarness(lessonGrade: string, studentGrade: string) {
+  const lessonContentOrder = vi.fn().mockResolvedValue({ data: [{ id: 'content-1' }], error: null });
+  const from = vi.fn((table: string) => {
+    if (table === 'lessons') {
+      return { select: vi.fn(() => ({ eq: vi.fn(() => terminal({
+        id: lessonId,
+        gradelevel: lessonGrade,
+        teacher_id: null,
+      })) })) };
+    }
+    if (table === 'students') {
+      return { select: vi.fn(() => ({ eq: vi.fn(() => terminal({ grade: studentGrade })) })) };
+    }
+    if (table === 'lesson_content') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({ order: lessonContentOrder })),
+            order: lessonContentOrder,
+          })),
+          order: lessonContentOrder,
+        })),
+      };
+    }
+    if (table === 'teachers') {
+      return { select: vi.fn(() => ({ eq: vi.fn(() => terminal(null)) })) };
+    }
+    throw new Error(`Unexpected table ${table}`);
+  });
+  createServerSupabaseMock.mockReturnValue({ from });
+  return { lessonContentOrder };
+}
+
+describe('student lesson content authorization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    getServerSessionMock.mockResolvedValue({ user: { id: 'student-1', role: 'student' } });
+  });
+
+  it.each([
+    ['content', async () => (await import('@/app/api/content/route')).GET],
+    ['resources', async () => (await import('@/app/api/resources/route')).GET],
+  ])('rejects %s from a lesson outside the student grade', async (_name, loadGet) => {
+    const harness = createHarness('JHS 2', 'JHS 1');
+    const GET = await loadGet();
+
+    const response = await GET(new Request(`http://localhost/api/content?lessonId=${lessonId}`));
+
+    expect(response.status).toBe(403);
+    expect(harness.lessonContentOrder).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['content', async () => (await import('@/app/api/content/route')).GET],
+    ['resources', async () => (await import('@/app/api/resources/route')).GET],
+  ])('allows %s for a student in the lesson grade', async (_name, loadGet) => {
+    createHarness('JHS 1', 'jhs 1');
+    const GET = await loadGet();
+
+    const response = await GET(new Request(`http://localhost/api/content?lessonId=${lessonId}`));
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/lib/lesson-artifacts/__tests__/student-lesson-route.test.ts
+++ b/src/lib/lesson-artifacts/__tests__/student-lesson-route.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requireStudentSessionMock = vi.fn();
+const createServerSupabaseMock = vi.fn();
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/lesson-artifacts/learning-server', () => ({
+  requireStudentSession: requireStudentSessionMock,
+}));
+
+vi.mock('@/lib/supabase.server', () => ({
+  createServerSupabase: createServerSupabaseMock,
+}));
+
+const lessonId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+type HarnessOptions = {
+  lesson?: Record<string, unknown> | null;
+  studentGrade?: string | null;
+  publication?: Record<string, unknown> | null;
+};
+
+function maybeSingle(result: { data: unknown; error: unknown }) {
+  return { maybeSingle: vi.fn().mockResolvedValue(result) };
+}
+
+function createHarness(options: HarnessOptions = {}) {
+  const lesson = options.lesson === undefined
+    ? { id: lessonId, gradelevel: 'JHS 1', current_publication_id: 'publication-1' }
+    : options.lesson;
+  const publication = options.publication === undefined
+    ? {
+        version: 7,
+        manifest: {
+          lesson: {
+            id: lessonId,
+            title: 'Published forces',
+            subject: 'Physics',
+            gradeLevel: 'JHS 1',
+            content: 'Immutable content',
+          },
+          objectives: [
+            { id: 'objective-2', text: 'Calculate net force.', position: 1, revision: 2, artifactIds: ['quiz-1'] },
+            { id: 'objective-1', text: 'Define force.', position: 0, revision: 3, artifactIds: ['visual-1'] },
+          ],
+        },
+      }
+    : options.publication;
+
+  const from = vi.fn((table: string) => {
+    if (table === 'lessons') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => maybeSingle({ data: lesson, error: null })),
+        })),
+      };
+    }
+    if (table === 'students') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => maybeSingle({ data: { grade: options.studentGrade ?? 'jhs 1' }, error: null })),
+        })),
+      };
+    }
+    if (table === 'lesson_publications') {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => maybeSingle({ data: publication, error: null })),
+        })),
+      };
+    }
+    if (table === 'lesson_artifacts') {
+      return {
+        select: vi.fn(() => ({
+          in: vi.fn().mockResolvedValue({
+            data: [
+              { id: 'visual-1', kind: 'interactive_visualization' },
+              { id: 'quiz-1', kind: 'structured_quiz' },
+            ],
+            error: null,
+          }),
+        })),
+      };
+    }
+    throw new Error(`Unexpected table ${table}`);
+  });
+
+  createServerSupabaseMock.mockReturnValue({ from });
+  return { from };
+}
+
+async function callGet() {
+  const { GET } = await import('@/app/api/students/lessons/[lessonId]/route');
+  const response = await GET(
+    new Request(`http://localhost/api/students/lessons/${lessonId}`),
+    { params: Promise.resolve({ lessonId }) },
+  );
+  return { response, json: await response.json() };
+}
+
+describe('student lesson detail route', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    requireStudentSessionMock.mockResolvedValue({ user: { id: 'student-1', role: 'student' } });
+  });
+
+  it('returns the immutable publication with ordered approved-artifact counts', async () => {
+    createHarness();
+
+    const { response, json } = await callGet();
+
+    expect(response.status).toBe(200);
+    expect(json.publicationVersion).toBe(7);
+    expect(json.lesson.title).toBe('Published forces');
+    expect(json.objectives.map((objective: { id: string }) => objective.id)).toEqual(['objective-1', 'objective-2']);
+    expect(json.objectives[0].artifactCounts).toEqual({ visualizations: 1, quizzes: 0, resources: 0 });
+    expect(json.objectives[1].artifactCounts).toEqual({ visualizations: 0, quizzes: 1, resources: 0 });
+  });
+
+  it('returns 403 when the publication is outside the student grade', async () => {
+    createHarness({ studentGrade: 'JHS 2' });
+
+    const { response } = await callGet();
+
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 404 for an unknown lesson', async () => {
+    createHarness({ lesson: null });
+
+    const { response } = await callGet();
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns an explicit unpublished response when no current publication exists', async () => {
+    createHarness({ lesson: { id: lessonId, gradelevel: 'JHS 1', current_publication_id: null } });
+
+    const { response, json } = await callGet();
+
+    expect(response.status).toBe(409);
+    expect(json.code).toBe('unpublished_lesson');
+  });
+
+  it('accepts a JSON-encoded structured objective snapshot', async () => {
+    const objectives = [{
+      id: '11111111-1111-4111-8111-111111111111',
+      text: 'Define force.',
+      position: 0,
+      revision: 1,
+      artifactIds: ['visual-1'],
+    }];
+    createHarness({ publication: {
+      version: 2,
+      manifest: {
+        lesson: { id: lessonId, title: 'Forces', subject: 'Physics', gradeLevel: 'JHS 1', content: null },
+        objectives: JSON.stringify(objectives),
+      },
+    } });
+
+    const { response, json } = await callGet();
+
+    expect(response.status).toBe(200);
+    expect(json.objectives[0].id).toBe(objectives[0].id);
+  });
+
+  it('returns a recoverable unpublished response for text-only legacy snapshots', async () => {
+    createHarness({ publication: {
+      version: 1,
+      manifest: {
+        lesson: { id: lessonId, title: 'Forces', subject: 'Physics', gradeLevel: 'JHS 1', content: null },
+        objectives: 'Define force.\nCalculate force.',
+      },
+    } });
+
+    const { response, json } = await callGet();
+
+    expect(response.status).toBe(409);
+    expect(json.code).toBe('unpublished_lesson');
+  });
+});

--- a/src/lib/lesson-artifacts/jobs.ts
+++ b/src/lib/lesson-artifacts/jobs.ts
@@ -27,6 +27,7 @@ export interface ContentJobRecord {
     version?: number;
     supersedesId?: string;
     assetId?: string;
+    taskDescription?: string;
   };
 }
 
@@ -45,8 +46,10 @@ export interface ArtifactGenerationDependencies {
   }>;
 }
 
-const contextFor = (job: ContentJobRecord) =>
-  `Lesson: ${job.input.lessonTitle}\nSubject: ${job.input.subject}\nGrade: ${job.input.gradeLevel}\nObjective: ${job.input.objectiveText}`;
+const contextFor = (job: ContentJobRecord) => {
+  const taskDescription = job.input.taskDescription?.trim();
+  return `Lesson: ${job.input.lessonTitle}\nSubject: ${job.input.subject}\nGrade: ${job.input.gradeLevel}\nObjective: ${job.input.objectiveText}${taskDescription ? `\nLearner request: ${taskDescription}` : ''}`;
+};
 
 export async function generateArtifactPayload(
   job: ContentJobRecord,

--- a/src/lib/lesson-artifacts/learning-server.ts
+++ b/src/lib/lesson-artifacts/learning-server.ts
@@ -42,6 +42,7 @@ export async function generateSessionArtifact(input: {
   objective: { id: string; text: string; revision: number };
   studentId: string;
   kind: 'visualization' | 'quiz';
+  taskDescription?: string;
 }) {
   const instanceId = randomUUID();
   const job: ContentJobRecord = {
@@ -59,6 +60,7 @@ export async function generateSessionArtifact(input: {
       objectiveText: input.objective.text,
       objectiveRevision: input.objective.revision,
       position: 999,
+      ...(input.taskDescription?.trim() ? { taskDescription: input.taskDescription.trim().slice(0, 500) } : {}),
     },
   };
   const payload = await generateArtifactPayload(job, {
@@ -94,6 +96,7 @@ export async function resolveNextLearningArtifact(input: {
   runId: string;
   kind: LearningArtifactKind;
   requestId: string;
+  taskDescription?: string;
 }) {
   const { session, supabase, run } = await requireOwnedLearningRun(input.runId);
   const { data: existing } = await supabase.from('learning_events').select('payload').eq('run_id', run.id).eq('request_id', input.requestId).maybeSingle();
@@ -152,6 +155,7 @@ export async function resolveNextLearningArtifact(input: {
       objective,
       studentId: session.user.id,
       kind: input.kind,
+      taskDescription: input.taskDescription,
     });
     instanceId = generated.instanceId;
     studentArtifact = generated.studentArtifact;

--- a/src/lib/lesson-artifacts/lesson-read-server.ts
+++ b/src/lib/lesson-artifacts/lesson-read-server.ts
@@ -1,0 +1,51 @@
+import 'server-only';
+
+import { getServerSession } from '@/lib/auth';
+import { createServerSupabase } from '@/lib/supabase.server';
+
+import { canManageLesson } from './access';
+import { LessonArtifactHttpError } from './server';
+
+export async function requireLessonViewer(lessonId: string) {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new LessonArtifactHttpError(401, 'Authentication required');
+
+  const supabase = createServerSupabase();
+  const { data: lesson, error: lessonError } = await supabase
+    .from('lessons')
+    .select('id,gradelevel,teacher_id')
+    .eq('id', lessonId)
+    .maybeSingle();
+  if (lessonError) throw lessonError;
+  if (!lesson) throw new LessonArtifactHttpError(404, 'Lesson not found');
+
+  if (session.user.role === 'student') {
+    const { data: student, error: studentError } = await supabase
+      .from('students')
+      .select('grade')
+      .eq('user_id', session.user.id)
+      .maybeSingle();
+    if (studentError) throw studentError;
+    const lessonGrade = lesson.gradelevel?.trim().toLowerCase();
+    const studentGrade = student?.grade?.trim().toLowerCase();
+    if (!lessonGrade || !studentGrade || lessonGrade !== studentGrade) {
+      throw new LessonArtifactHttpError(403, 'This lesson is not assigned to your grade');
+    }
+    return { session, supabase, lesson };
+  }
+
+  let normalizedTeacherUserId: string | null = null;
+  if (lesson.teacher_id) {
+    const { data: teacher, error: teacherError } = await supabase
+      .from('teachers')
+      .select('user_id')
+      .eq('id', lesson.teacher_id)
+      .maybeSingle();
+    if (teacherError) throw teacherError;
+    normalizedTeacherUserId = teacher?.user_id ?? null;
+  }
+  if (!canManageLesson({ user: session.user, lesson, normalizedTeacherUserId })) {
+    throw new LessonArtifactHttpError(403, 'Not authorized to view this lesson');
+  }
+  return { session, supabase, lesson };
+}

--- a/src/lib/lesson-artifacts/lesson-runtime-compatibility.ts
+++ b/src/lib/lesson-artifacts/lesson-runtime-compatibility.ts
@@ -1,0 +1,23 @@
+// Bounded compatibility set for teacher-approved React artifacts. Dynamic values
+// should use inline styles; generated components may rely on these common utilities.
+export const LESSON_RUNTIME_COMPATIBILITY_CLASSES = [
+  'grid-cols-1', 'grid-cols-2', 'grid-cols-3', 'grid-cols-4',
+  'sm:grid-cols-2', 'md:grid-cols-2', 'md:grid-cols-3', 'md:grid-cols-4',
+  'col-span-1', 'col-span-2', 'col-span-3', 'col-span-4',
+  'flex-row', 'flex-col', 'flex-wrap', 'flex-nowrap', 'grow', 'shrink-0',
+  'inset-0', 'inset-x-0', 'inset-y-0', 'top-0', 'right-0', 'bottom-0', 'left-0',
+  'aspect-square', 'aspect-video',
+  'w-1/2', 'w-1/3', 'w-2/3', 'w-1/4', 'w-3/4',
+  'h-1/2', 'h-1/3', 'h-2/3',
+  'bg-gradient-to-r', 'bg-gradient-to-br', 'bg-gradient-to-b',
+  'from-blue-500', 'to-purple-500', 'from-cyan-400', 'to-blue-600',
+  'from-emerald-400', 'to-green-600', 'from-amber-400', 'to-orange-600',
+  'from-pink-400', 'to-rose-600', 'via-indigo-500',
+  'transform', 'transition-transform', 'transition-colors', 'transition-opacity',
+  'ease-in', 'ease-out', 'ease-in-out',
+  'hover:scale-105', 'hover:scale-110', 'active:scale-95',
+  'hover:-translate-y-1', 'hover:bg-blue-600', 'hover:bg-emerald-600',
+  'focus:outline-none', 'focus:ring-2', 'focus:ring-blue-500',
+  'disabled:cursor-not-allowed', 'disabled:opacity-50',
+  'z-0', 'z-10', 'z-20', 'z-30', 'z-40', 'z-50',
+] as const;

--- a/src/lib/lesson-artifacts/objective-learning-controller.ts
+++ b/src/lib/lesson-artifacts/objective-learning-controller.ts
@@ -1,0 +1,81 @@
+export function createAsyncRequestDeduper() {
+  const inFlight = new Map<string, Promise<unknown>>();
+
+  return {
+    run<T>(key: string, operation: () => Promise<T>): Promise<T> {
+      const existing = inFlight.get(key) as Promise<T> | undefined;
+      if (existing) return existing;
+
+      const request = operation().finally(() => {
+        if (inFlight.get(key) === request) inFlight.delete(key);
+      });
+      inFlight.set(key, request);
+      return request;
+    },
+  };
+}
+
+export type LearningScopeToken = Readonly<{
+  scope: string;
+  version: number;
+}>;
+
+export function createLearningScopeGuard() {
+  let scope: string | null = null;
+  let version = 0;
+
+  return {
+    begin(nextScope: string): LearningScopeToken {
+      scope = nextScope;
+      version += 1;
+      return { scope, version };
+    },
+    clear() {
+      scope = null;
+      version += 1;
+    },
+    isCurrent(token: LearningScopeToken) {
+      return scope === token.scope && version === token.version;
+    },
+  };
+}
+
+export function appendUniqueArtifact<T extends { instanceId: string }>(current: T[], next: T): T[] {
+  return current.some((artifact) => artifact.instanceId === next.instanceId)
+    ? current
+    : [...current, next];
+}
+
+export type ObjectiveLearningArtifact = {
+  instanceId: string;
+  source: 'teacher_approved' | 'session_generated';
+  exhausted: boolean;
+  artifact: {
+    id: string;
+    kind: 'interactive_visualization' | 'generated_image' | 'structured_quiz' | 'visual_quiz' | 'uploaded_media';
+    payload: any;
+  } & Record<string, unknown>;
+};
+
+export function normalizeRequestedArtifactKind(value: unknown): 'visualization' | 'quiz' {
+  return value === 'quiz' ? 'quiz' : 'visualization';
+}
+
+export function buildObjectiveTutorPromptContext(input: {
+  lessonTitle: string;
+  subject?: string;
+  gradeLevel?: string;
+  objectiveText: string;
+  lessonContent?: string | null;
+}): string {
+  const content = input.lessonContent?.trim();
+  return `
+### Objective-focused lesson session
+- Lesson: ${input.lessonTitle}
+- Subject: ${input.subject || 'Not specified'}
+- Grade level: ${input.gradeLevel || 'Not specified'}
+- Active objective: ${input.objectiveText}
+
+Keep the entire session focused on the active objective. When a visual, illustration, or knowledge check would help, call request_learning_artifact with kind "visualization" or "quiz". That tool always uses teacher-reviewed activities before it creates a new activity.
+${content ? `\nPublished lesson context:\n${content.slice(0, 2000)}` : ''}`.trim();
+}

--- a/src/lib/lesson-artifacts/react-sandbox-runtime.ts
+++ b/src/lib/lesson-artifacts/react-sandbox-runtime.ts
@@ -1,27 +1,31 @@
 export const REACT_SANDBOX_SOURCES = {
   react: '/lesson-runtime/react-18.3.1.production.min.js',
   reactDom: '/lesson-runtime/react-dom-18.3.1.production.min.js',
+  tailwindCss: '/lesson-runtime/tailwind.generated.css',
 } as const;
 
-export type ReactSandboxSourceText = { react: string; reactDom: string };
+export type ReactSandboxSourceText = { react: string; reactDom: string; tailwindCss: string };
 
 export async function fetchReactSandboxSources(
   fetcher: typeof fetch = globalThis.fetch,
 ): Promise<ReactSandboxSourceText> {
-  const [reactResponse, reactDomResponse] = await Promise.all([
+  const [reactResponse, reactDomResponse, tailwindResponse] = await Promise.all([
     fetcher(REACT_SANDBOX_SOURCES.react),
     fetcher(REACT_SANDBOX_SOURCES.reactDom),
+    fetcher(REACT_SANDBOX_SOURCES.tailwindCss),
   ]);
-  if (!reactResponse.ok || !reactDomResponse.ok) throw new Error('Failed to load React runtime assets');
-  const [react, reactDom] = await Promise.all([reactResponse.text(), reactDomResponse.text()]);
-  return { react, reactDom };
+  if (!reactResponse.ok || !reactDomResponse.ok || !tailwindResponse.ok) throw new Error('Failed to load React runtime assets');
+  const [react, reactDom, tailwindCss] = await Promise.all([reactResponse.text(), reactDomResponse.text(), tailwindResponse.text()]);
+  return { react, reactDom, tailwindCss };
 }
 
 const escapeInlineScript = (source: string) => source.replace(/<\/script/gi, '<\\/script');
+const escapeInlineStyle = (source: string) => source.replace(/<\/style/gi, '<\\/style');
 
 export function renderReactSandboxScripts(nonce: string, sources: ReactSandboxSourceText): string {
   if (!/^[a-zA-Z0-9_-]+$/.test(nonce)) throw new Error('Invalid sandbox script nonce');
   return `
+  <style nonce="${nonce}">${escapeInlineStyle(sources.tailwindCss)}</style>
   <script nonce="${nonce}">${escapeInlineScript(sources.react)}</script>
   <script nonce="${nonce}">${escapeInlineScript(sources.reactDom)}</script>
   <script nonce="${nonce}">

--- a/src/lib/lesson-artifacts/student-learning.ts
+++ b/src/lib/lesson-artifacts/student-learning.ts
@@ -1,0 +1,150 @@
+export type PublishedObjective = {
+  id: string;
+  text: string;
+  position: number;
+  revision: number;
+  artifactIds?: string[];
+};
+
+export type StudentObjectiveSummary = Omit<PublishedObjective, 'artifactIds'> & {
+  artifactCounts: {
+    visualizations: number;
+    quizzes: number;
+    resources: number;
+  };
+};
+
+export type StudentLessonDetail = {
+  lesson: {
+    id: string;
+    title: string;
+    subject: string;
+    gradeLevel: string;
+    content: string | null;
+  };
+  publicationVersion: number;
+  objectives: StudentObjectiveSummary[];
+};
+
+type PublishedArtifactSummary = {
+  id: string;
+  kind: string;
+};
+
+const cleanObjectiveList = (values: unknown[]) => values
+  .filter((value): value is string => typeof value === 'string')
+  .map((value) => value.trim())
+  .filter(Boolean);
+
+export function normalizeLegacyObjectives(value: unknown): string[] {
+  if (Array.isArray(value)) return cleanObjectiveList(value);
+  if (typeof value !== 'string' || !value.trim()) return [];
+
+  const trimmed = value.trim();
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) return cleanObjectiveList(parsed);
+    } catch {
+      // Fall back to the human-entered newline format.
+    }
+  }
+
+  return cleanObjectiveList(trimmed.split(/\r?\n/));
+}
+
+export function normalizePublishedObjectives(value: unknown): PublishedObjective[] | null {
+  let candidate = value;
+  if (typeof candidate === 'string') {
+    try {
+      candidate = JSON.parse(candidate);
+    } catch {
+      return null;
+    }
+  }
+  if (!Array.isArray(candidate)) return null;
+
+  const normalized: PublishedObjective[] = [];
+  const ids = new Set<string>();
+  for (const item of candidate) {
+    if (!item || typeof item !== 'object') return null;
+    const objective = item as Record<string, unknown>;
+    const id = typeof objective.id === 'string' ? objective.id.trim() : '';
+    const text = typeof objective.text === 'string' ? objective.text.trim() : '';
+    const position = objective.position;
+    const revision = objective.revision;
+    const artifactIds = objective.artifactIds;
+    if (
+      !id || ids.has(id) || !text
+      || !Number.isInteger(position) || Number(position) < 0
+      || !Number.isInteger(revision) || Number(revision) < 1
+      || (artifactIds !== undefined && (
+        !Array.isArray(artifactIds)
+        || artifactIds.some((artifactId) => typeof artifactId !== 'string' || !artifactId.trim())
+      ))
+    ) return null;
+
+    ids.add(id);
+    normalized.push({
+      id,
+      text,
+      position: Number(position),
+      revision: Number(revision),
+      ...(Array.isArray(artifactIds) ? { artifactIds: artifactIds.map((artifactId) => artifactId.trim()) } : {}),
+    });
+  }
+  return normalized;
+}
+
+export function selectPublishedObjective<T extends PublishedObjective>(
+  objectives: T[],
+  requestedObjectiveId?: string,
+): T | undefined {
+  if (requestedObjectiveId) return objectives.find((objective) => objective.id === requestedObjectiveId);
+  return [...objectives].sort((left, right) => left.position - right.position)[0];
+}
+
+export function isObjectiveSelectionChange(
+  currentObjectiveId: string | null | undefined,
+  nextObjectiveId: string,
+): boolean {
+  return Boolean(currentObjectiveId && currentObjectiveId !== nextObjectiveId);
+}
+
+export function summarizePublishedObjectives(input: {
+  objectives: PublishedObjective[];
+  artifacts: PublishedArtifactSummary[];
+}): StudentObjectiveSummary[] {
+  const artifactsById = new Map(input.artifacts.map((artifact) => [artifact.id, artifact]));
+
+  return [...input.objectives]
+    .sort((left, right) => left.position - right.position)
+    .map(({ artifactIds = [], ...objective }) => {
+      const counts = { visualizations: 0, quizzes: 0, resources: 0 };
+      for (const artifactId of artifactIds) {
+        const kind = artifactsById.get(artifactId)?.kind;
+        if (['interactive_visualization', 'generated_image'].includes(kind ?? '')) counts.visualizations += 1;
+        if (['structured_quiz', 'visual_quiz'].includes(kind ?? '')) counts.quizzes += 1;
+        if (kind === 'uploaded_media') counts.resources += 1;
+      }
+      return { ...objective, artifactCounts: counts };
+    });
+}
+
+export function buildStudentLessonDetail(input: {
+  publicationVersion: number;
+  manifest: {
+    lesson: StudentLessonDetail['lesson'];
+    objectives: PublishedObjective[];
+  };
+  artifacts: PublishedArtifactSummary[];
+}): StudentLessonDetail {
+  return {
+    lesson: input.manifest.lesson,
+    publicationVersion: input.publicationVersion,
+    objectives: summarizePublishedObjectives({
+      objectives: input.manifest.objectives,
+      artifacts: input.artifacts,
+    }),
+  };
+}

--- a/src/lib/student-profile.ts
+++ b/src/lib/student-profile.ts
@@ -1,0 +1,25 @@
+export type StudentProfile = {
+  name: string | null;
+  email: string | null;
+  gradeLevel: string | null;
+};
+
+export const studentProfileQueryKey = (userId?: string | null) => (
+  ['student-profile', userId ?? 'anonymous'] as const
+);
+
+const clean = (value: unknown) => typeof value === 'string' && value.trim() ? value.trim() : undefined;
+
+export function resolveStudentDisplayName(input: {
+  profileName?: unknown;
+  metadataName?: unknown;
+  email?: unknown;
+}): string {
+  const profileName = clean(input.profileName);
+  if (profileName) return profileName;
+  const metadataName = clean(input.metadataName);
+  if (metadataName) return metadataName;
+  const email = clean(input.email);
+  if (email) return email.split('@')[0] || 'there';
+  return 'there';
+}

--- a/src/lib/visualize-ai-task.ts
+++ b/src/lib/visualize-ai-task.ts
@@ -92,7 +92,7 @@ Subtract 96px from provided width and height for your canvas or root element to 
 - **SPEED RULE:** Do not write huge arrays of quiz questions. Write 1–2 powerful interactive questions max.
 - Available charts (Recharts): LineChart, BarChart, PieChart, AreaChart, ScatterChart, RadarChart, and all standard sub-components.
 - Available maps (React-Leaflet): MapContainer, TileLayer, Marker, Popup, Polyline, Polygon, Circle, useMap.
-- Styling: Tailwind utility classes for standard styles; inline \`style\` props for gradients and dynamic values. No \`@import \`, no CSS variables.
+- Styling: Use common Tailwind layout, spacing, typography, palette, border, and shadow utilities only. Use inline \`style\` props for gradients, transforms, arbitrary values, and dynamic values. No arbitrary bracket classes, \`@import\`, or CSS variables.
 - Images: Use \`React.createElement('img', { src, alt, style })\`. Extract URLs from markdown syntax in the task description.
 
 ### Three.js & p5.js Rules

--- a/src/styles/lesson-runtime.css
+++ b/src/styles/lesson-runtime.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.lesson-runtime.config.ts
+++ b/tailwind.lesson-runtime.config.ts
@@ -1,0 +1,29 @@
+import type { Config } from 'tailwindcss';
+
+import { LESSON_RUNTIME_COMPATIBILITY_CLASSES } from './src/lib/lesson-artifacts/lesson-runtime-compatibility';
+
+const colors = '(slate|gray|zinc|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)';
+const shades = '(50|100|200|300|400|500|600|700|800|900|950)';
+
+export default {
+  content: [
+    './src/components/lessons/ReactRenderer.tsx',
+    './src/lib/visualize-ai-task.ts',
+  ],
+  safelist: [
+    { pattern: new RegExp(`^(bg|text|border|ring)-${colors}-${shades}$`) },
+    { pattern: /^(flex|grid|block|inline|inline-flex|hidden|relative|absolute|fixed|overflow-hidden|overflow-auto)$/ },
+    { pattern: /^(items|justify|content)-(start|end|center|between|around|evenly|stretch)$/ },
+    { pattern: /^(w|h|min-w|min-h|max-w|max-h)-(full|screen|fit|min|max|auto)$/ },
+    { pattern: /^(rounded|shadow)(-none|-sm|-md|-lg|-xl|-2xl|-3xl|-full)?$/ },
+    { pattern: /^(font)-(normal|medium|semibold|bold|extrabold)$/ },
+    { pattern: /^(text)-(xs|sm|base|lg|xl|2xl|3xl|4xl|5xl|center|left|right)$/ },
+    { pattern: /^(gap|space-x|space-y|p|px|py|pt|pr|pb|pl|m|mx|my|mt|mr|mb|ml)-(0|0\.5|1|1\.5|2|2\.5|3|3\.5|4|5|6|8|10|12|16|20|24)$/ },
+    { pattern: /^(w|h|min-w|min-h|max-w|max-h)-(0|1|2|3|4|5|6|8|10|12|16|20|24|32|40|48|56|64|72|80|96)$/ },
+    { pattern: /^(opacity)-(0|10|20|25|30|40|50|60|70|75|80|90|100)$/ },
+    'transition', 'transition-all', 'duration-200', 'duration-300', 'cursor-pointer', 'select-none',
+    ...LESSON_RUNTIME_COMPATIBILITY_CLASSES,
+  ],
+  theme: { extend: {} },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- add canonical objective-based student lesson details and tutor startup
- reuse teacher-approved visualizations and quizzes before session-generated fallback
- secure lesson content access and harden objective session state
- replace runtime Tailwind CDN usage with a bounded local stylesheet

## Impact
Students can start the AI tutor from a published lesson objective and receive reviewed activities before on-demand generation. Teachers retain control over bundled lesson artifacts.

## Validation
- 154 tests passed
- TypeScript passed
- ESLint: 0 errors
- production build passed
- no database migration required